### PR TITLE
Synchronize local file and DynamoDB table

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,12 @@ $ valec namespaces
 hoge
 ```
 
-### `valec save`
+### `valec sync`
 
-Save secrets in local file to DynamoDB
+Synchronize secrets between local file and DynamoDB
 
 ```bash
-$ valec save hoge.yaml
+$ valec sync hoge.yaml
 ```
 
 ## Development

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -15,10 +15,10 @@ var (
 	yamlExtRegexp = regexp.MustCompile(`\.[yY][aA]?[mM][lL]$`)
 )
 
-// saveCmd represents the save command
-var saveCmd = &cobra.Command{
-	Use:   "save",
-	Short: "Save secrets in local file to DynamoDB",
+// syncCmd represents the sync command
+var syncCmd = &cobra.Command{
+	Use:   "sync",
+	Short: "Synchronize secrets between local file and DynamoDB",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) != 1 {
 			return errors.New("Please specify config file.")
@@ -36,12 +36,12 @@ var saveCmd = &cobra.Command{
 			return errors.Wrapf(err, "Failed to insert configs. namespace=%s", namespace)
 		}
 
-		fmt.Printf("%d configs of %q namespace are successfully saved!\n", len(configs), namespace)
+		fmt.Printf("%d configs of %q namespace are successfully synchronized!\n", len(configs), namespace)
 
 		return nil
 	},
 }
 
 func init() {
-	RootCmd.AddCommand(saveCmd)
+	RootCmd.AddCommand(syncCmd)
 }

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -25,7 +25,7 @@ var syncCmd = &cobra.Command{
 		}
 		filename := args[0]
 
-		configs, err := lib.LoadConfigYAML(filename)
+		srcConfigs, err := lib.LoadConfigYAML(filename)
 		if err != nil {
 			return errors.Wrapf(err, "Failed to load configs. filename=%s", filename)
 		}
@@ -38,11 +38,32 @@ var syncCmd = &cobra.Command{
 			namespace = args[1]
 		}
 
-		if err := aws.DynamoDB().Insert(tableName, namespace, configs); err != nil {
+		dstConfigs, err := aws.DynamoDB().ListConfigs(tableName, namespace)
+		if err != nil {
+			return errors.Wrapf(err, "Failed to retrieve configs. namespace=%s", namespace)
+		}
+
+		added, deleted := lib.CompareConfigList(srcConfigs, dstConfigs)
+
+		if err := aws.DynamoDB().Delete(tableName, namespace, deleted); err != nil {
+			return errors.Wrapf(err, "Failed to delete configs. namespace=%s", namespace)
+		}
+
+		if len(deleted) > 0 {
+			fmt.Printf("%d configs of %q namespace were successfully deleted!\n", len(deleted), namespace)
+		} else {
+			fmt.Println("No config was deleted.")
+		}
+
+		if err := aws.DynamoDB().Insert(tableName, namespace, added); err != nil {
 			return errors.Wrapf(err, "Failed to insert configs. namespace=%s", namespace)
 		}
 
-		fmt.Printf("%d configs of %q namespace are successfully synchronized!\n", len(configs), namespace)
+		if len(added) > 0 {
+			fmt.Printf("%d configs of %q namespace were successfully added!\n", len(added), namespace)
+		} else {
+			fmt.Println("No config was added.")
+		}
 
 		return nil
 	},

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -17,10 +17,10 @@ var (
 
 // syncCmd represents the sync command
 var syncCmd = &cobra.Command{
-	Use:   "sync",
+	Use:   "sync CONFIGFILE [NAMESPACE]",
 	Short: "Synchronize secrets between local file and DynamoDB",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if len(args) != 1 {
+		if len(args) < 1 {
 			return errors.New("Please specify config file.")
 		}
 		filename := args[0]
@@ -30,7 +30,13 @@ var syncCmd = &cobra.Command{
 			return errors.Wrapf(err, "Failed to load configs. filename=%s", filename)
 		}
 
-		namespace := yamlExtRegexp.ReplaceAllString(filepath.Base(filename), "")
+		var namespace string
+
+		if len(args) == 1 {
+			namespace = yamlExtRegexp.ReplaceAllString(filepath.Base(filename), "")
+		} else {
+			namespace = args[1]
+		}
 
 		if err := aws.DynamoDB().Insert(tableName, namespace, configs); err != nil {
 			return errors.Wrapf(err, "Failed to insert configs. namespace=%s", namespace)

--- a/lib/types.go
+++ b/lib/types.go
@@ -13,6 +13,35 @@ type Config struct {
 	Value string `yaml:"value"`
 }
 
+// CompareConfigList compares two config lists and returns the differences between them
+func CompareConfigList(src, dst []*Config) ([]*Config, []*Config) {
+	added, deleted := []*Config{}, []*Config{}
+
+	for _, c := range src {
+		if !configExists(c, dst) {
+			added = append(added, c)
+		}
+	}
+
+	for _, c := range dst {
+		if !configExists(c, src) {
+			deleted = append(deleted, c)
+		}
+	}
+
+	return added, deleted
+}
+
+func configExists(config *Config, configs []*Config) bool {
+	for _, c := range configs {
+		if config.Key == c.Key && config.Value == c.Value {
+			return true
+		}
+	}
+
+	return false
+}
+
 // LoadConfigYAML loads configs from the given YAML file
 func LoadConfigYAML(filename string) ([]*Config, error) {
 	body, err := ioutil.ReadFile(filename)

--- a/lib/types_test.go
+++ b/lib/types_test.go
@@ -7,6 +7,104 @@ import (
 	"testing"
 )
 
+func TestCompareConfigList(t *testing.T) {
+	src := []*Config{
+		&Config{
+			Key:   "FOO",
+			Value: "bar",
+		},
+		&Config{
+			Key:   "BAZ",
+			Value: "1",
+		},
+		&Config{
+			Key:   "HOGE",
+			Value: "fuga",
+		},
+	}
+	dst := []*Config{
+		&Config{
+			Key:   "FOO",
+			Value: "baz",
+		},
+		&Config{
+			Key:   "BAZ",
+			Value: "1",
+		},
+		&Config{
+			Key:   "QUX",
+			Value: "true",
+		},
+		&Config{
+			Key:   "PIYO",
+			Value: "piyo",
+		},
+	}
+
+	expectAdded := []*Config{
+		&Config{
+			Key:   "FOO",
+			Value: "bar",
+		},
+		&Config{
+			Key:   "HOGE",
+			Value: "fuga",
+		},
+	}
+	expectDeleted := []*Config{
+		&Config{
+			Key:   "FOO",
+			Value: "baz",
+		},
+		&Config{
+			Key:   "QUX",
+			Value: "true",
+		},
+		&Config{
+			Key:   "PIYO",
+			Value: "piyo",
+		},
+	}
+
+	added, deleted := CompareConfigList(src, dst)
+
+	if !configListsEqual(added, expectAdded) {
+		t.Errorf("Returned added configs are wrong. expected: %s, actual: %s", stringifyConfigList(expectAdded), stringifyConfigList(added))
+	}
+
+	if !configListsEqual(deleted, expectDeleted) {
+		t.Errorf("Returned deleted configs are wrong. expected: %s, actual: %s", stringifyConfigList(expectDeleted), stringifyConfigList(deleted))
+	}
+}
+
+func configListsEqual(a, b []*Config) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i := range a {
+		if a[i].Key != b[i].Key {
+			return false
+		}
+
+		if a[i].Value != b[i].Value {
+			return false
+		}
+	}
+
+	return true
+}
+
+func stringifyConfigList(configs []*Config) string {
+	ss := []string{}
+
+	for _, config := range configs {
+		ss = append(ss, fmt.Sprintf("%#v", config))
+	}
+
+	return fmt.Sprintf("[%s]", strings.Join(ss, ", "))
+}
+
 func TestLoadConfigFromYAML_valid(t *testing.T) {
 	filepath := testdataPath("test_valid.yaml")
 	configs, err := LoadConfigYAML(filepath)


### PR DESCRIPTION
## WHAT

Rename `save` command as `sync`. This command synchronizes local config file and DynamoDB table. Local file always priors to DynamoDB table.