### PR TITLE
Convert configs to map

### DIFF
--- a/lib/types.go
+++ b/lib/types.go
@@ -16,15 +16,18 @@ type Config struct {
 // CompareConfigList compares two config lists and returns the differences between them
 func CompareConfigList(src, dst []*Config) ([]*Config, []*Config) {
 	added, deleted := []*Config{}, []*Config{}
+	srcMap, dstMap := ConfigsToMap(src), ConfigsToMap(dst)
 
 	for _, c := range src {
-		if !configExists(c, dst) {
+		v, ok := dstMap[c.Key]
+		if !ok || v != c.Value {
 			added = append(added, c)
 		}
 	}
 
 	for _, c := range dst {
-		if !configExists(c, src) {
+		v, ok := srcMap[c.Key]
+		if !ok || v != c.Value {
 			deleted = append(deleted, c)
 		}
 	}
@@ -41,16 +44,6 @@ func ConfigsToMap(configs []*Config) map[string]string {
 	}
 
 	return configMap
-}
-
-func configExists(config *Config, configs []*Config) bool {
-	for _, c := range configs {
-		if config.Key == c.Key && config.Value == c.Value {
-			return true
-		}
-	}
-
-	return false
 }
 
 // LoadConfigYAML loads configs from the given YAML file

--- a/lib/types.go
+++ b/lib/types.go
@@ -32,6 +32,17 @@ func CompareConfigList(src, dst []*Config) ([]*Config, []*Config) {
 	return added, deleted
 }
 
+// ConfigsToMap converts config list to map
+func ConfigsToMap(configs []*Config) map[string]string {
+	configMap := map[string]string{}
+
+	for _, config := range configs {
+		configMap[config.Key] = config.Value
+	}
+
+	return configMap
+}
+
 func configExists(config *Config, configs []*Config) bool {
 	for _, c := range configs {
 		if config.Key == c.Key && config.Value == c.Value {

--- a/lib/types_test.go
+++ b/lib/types_test.go
@@ -3,6 +3,7 @@ package lib
 import (
 	"fmt"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -133,6 +134,34 @@ func TestLoadConfigFromYAML_valid(t *testing.T) {
 		if config.Value != expects[i].value {
 			t.Errorf("Config value does not match. expected: %s, actual: %s", expects[i].value, config.Value)
 		}
+	}
+}
+
+func TestConfigsToMap(t *testing.T) {
+	configs := []*Config{
+		&Config{
+			Key:   "FOO",
+			Value: "bar",
+		},
+		&Config{
+			Key:   "BAZ",
+			Value: "1",
+		},
+		&Config{
+			Key:   "HOGE",
+			Value: "fuga",
+		},
+	}
+	expected := map[string]string{
+		"FOO":  "bar",
+		"BAZ":  "1",
+		"HOGE": "fuga",
+	}
+
+	configMap := ConfigsToMap(configs)
+
+	if !reflect.DeepEqual(configMap, expected) {
+		t.Errorf("Config map does not match. expected: %q, actual:%q", expected, configMap)
 	}
 }
 


### PR DESCRIPTION
## WHY

When we search config from configs `[]*Config`, we have to use linear search or binary search or something else. It takes more computational complexity. For example, `CompareConfigList` requires `O(MN)`.

## WHAT

Implement method to convert configs `[]*Config` to `map[string]string`. This makes computational complexity smaller. For example, `CompareConfigList` requires `O(M+N)`.

## BENCHMARK

<details>
<summary>Code</summary>

```go
package lib

import (
	"strconv"
	"testing"
)

func BenchmarkCompareConfigList(b *testing.B) {
	src, dst := []*Config{}, []*Config{}

	for i := 0; i < b.N; i++ {
		src = append(src, &Config{
			Key:   strconv.Itoa(i),
			Value: strconv.Itoa(i),
		})
		dst = append(dst, &Config{
			Key:   strconv.Itoa(b.N - 1 - i),
			Value: strconv.Itoa(b.N - 1 - i),
		})
	}

	b.ResetTimer()

	_, _ = CompareConfigList(src, dst)
}
```

</details>

### Before

```
BenchmarkCompareConfigList-4       30000            163875 ns/op
PASS
```

### After

```
BenchmarkCompareConfigList-4     1000000              2254 ns/op
PASS
```