### PR TITLE
Add --add flag to encrypt command

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,22 @@ YEAR=2015
 SSSS=
 ```
 
+### `valec encrypt`
+
+Encrypt secret
+
+With `--add FILE` flag, encrypted secret will be added to the specified file.
+
+```bash
+$ valec encrypt NAME=awesome
+AQECAHi1osu8IsEnPMo1...
+
+$ valec encrypt NAME=awesome --add secrets.yml
+$ cat secrets.yml
+- key: NAME
+  value: AQECAHi1osu8IsEnPMo1...
+```
+
 ### `valec exec`
 
 Execute commands using stored secrets

--- a/cmd/encrypt.go
+++ b/cmd/encrypt.go
@@ -35,22 +35,21 @@ var encryptCmd = &cobra.Command{
 		if configFile == "" {
 			fmt.Println(cipherText)
 		} else {
-			configs := []*lib.Config{}
+			configMap := map[string]string{}
 
 			if _, err := os.Stat(configFile); err == nil {
-				var err2 error
-				configs, err2 = lib.LoadConfigYAML(configFile)
+				configs, err2 := lib.LoadConfigYAML(configFile)
 				if err2 != nil {
 					return errors.Wrapf(err2, "Failed to load local config file. filename=%s", configFile)
 				}
+
+				configMap = lib.ConfigsToMap(configs)
 			}
 
-			configs = append(configs, &lib.Config{
-				Key:   key,
-				Value: cipherText,
-			})
+			configMap[key] = cipherText
+			newConfigs := lib.MapToConfigs(configMap)
 
-			if err := lib.SaveAsYAML(configs, configFile); err != nil {
+			if err := lib.SaveAsYAML(newConfigs, configFile); err != nil {
 				return errors.Wrapf(err, "Failed to update local config file. filename=%s", configFile)
 			}
 		}

--- a/cmd/encrypt.go
+++ b/cmd/encrypt.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/dtan4/valec/aws"
@@ -34,9 +35,14 @@ var encryptCmd = &cobra.Command{
 		if configFile == "" {
 			fmt.Println(cipherText)
 		} else {
-			configs, err := lib.LoadConfigYAML(configFile)
-			if err != nil {
-				return errors.Wrapf(err, "Failed to load local config file. filename=%s", configFile)
+			configs := []*lib.Config{}
+
+			if _, err := os.Stat(configFile); err == nil {
+				var err2 error
+				configs, err2 = lib.LoadConfigYAML(configFile)
+				if err2 != nil {
+					return errors.Wrapf(err2, "Failed to load local config file. filename=%s", configFile)
+				}
 			}
 
 			configs = append(configs, &lib.Config{

--- a/cmd/encrypt.go
+++ b/cmd/encrypt.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/dtan4/valec/aws"
+	"github.com/dtan4/valec/lib"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -30,7 +31,23 @@ var encryptCmd = &cobra.Command{
 			return errors.Wrapf(err, "Failed to encrypt.")
 		}
 
-		fmt.Println(cipherText)
+		if configFile == "" {
+			fmt.Println(cipherText)
+		} else {
+			configs, err := lib.LoadConfigYAML(configFile)
+			if err != nil {
+				return errors.Wrapf(err, "Failed to load local config file. filename=%s", configFile)
+			}
+
+			configs = append(configs, &lib.Config{
+				Key:   key,
+				Value: cipherText,
+			})
+
+			if err := lib.SaveAsYAML(configs, configFile); err != nil {
+				return errors.Wrapf(err, "Failed to update local config file. filename=%s", configFile)
+			}
+		}
 
 		return nil
 	},
@@ -38,4 +55,6 @@ var encryptCmd = &cobra.Command{
 
 func init() {
 	RootCmd.AddCommand(encryptCmd)
+
+	encryptCmd.Flags().StringVar(&configFile, "add", "", "Add to local config file")
 }

--- a/lib/types.go
+++ b/lib/types.go
@@ -61,3 +61,17 @@ func LoadConfigYAML(filename string) ([]*Config, error) {
 
 	return configs, nil
 }
+
+// SaveAsYAML saves configs to local config file
+func SaveAsYAML(configs []*Config, filename string) error {
+	body, err := yaml.Marshal(configs)
+	if err != nil {
+		return errors.Wrap(err, "Failed to convert configs as YAML.")
+	}
+
+	if err := ioutil.WriteFile(filename, body, 0644); err != nil {
+		return errors.Wrapf(err, "Failed to save file. filename=%s", filename)
+	}
+
+	return nil
+}

--- a/lib/types.go
+++ b/lib/types.go
@@ -62,6 +62,20 @@ func LoadConfigYAML(filename string) ([]*Config, error) {
 	return configs, nil
 }
 
+// MapToConfigs converts map to config list
+func MapToConfigs(configMap map[string]string) []*Config {
+	configs := []*Config{}
+
+	for key, value := range configMap {
+		configs = append(configs, &Config{
+			Key:   key,
+			Value: value,
+		})
+	}
+
+	return configs
+}
+
 // SaveAsYAML saves configs to local config file
 func SaveAsYAML(configs []*Config, filename string) error {
 	body, err := yaml.Marshal(configs)

--- a/lib/types_test.go
+++ b/lib/types_test.go
@@ -2,6 +2,8 @@ package lib
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -195,4 +197,41 @@ func TestLoadConfigFromYAML_notexist(t *testing.T) {
 
 func testdataPath(name string) string {
 	return filepath.Join("..", "testdata", name)
+}
+
+func TestSaveAsYAML(t *testing.T) {
+	configs := []*Config{
+		&Config{
+			Key:   "FOO",
+			Value: "bar",
+		},
+		&Config{
+			Key:   "BAZ",
+			Value: "1",
+		},
+		&Config{
+			Key:   "HOGE",
+			Value: "fuga",
+		},
+	}
+
+	dir, err := ioutil.TempDir("", "test-save-as-yaml")
+	if err != nil {
+		t.Fatalf("Failed to create tempdir. dir: %s", dir)
+	}
+	defer os.RemoveAll(dir)
+
+	filename := filepath.Join(dir, "config.yaml")
+
+	if err := SaveAsYAML(configs, filename); err != nil {
+		t.Fatalf("Error should not be raised. err: %s", err)
+	}
+
+	if _, err := os.Stat(filename); err != nil {
+		if os.IsNotExist(err) {
+			t.Fatalf("File is not created. err: %s", err)
+		} else {
+			t.Fatalf("Saved file has something wrong. err: %s", err)
+		}
+	}
 }

--- a/lib/types_test.go
+++ b/lib/types_test.go
@@ -199,6 +199,34 @@ func testdataPath(name string) string {
 	return filepath.Join("..", "testdata", name)
 }
 
+func TestMapToConfigs(t *testing.T) {
+	configMap := map[string]string{
+		"FOO":  "bar",
+		"BAZ":  "1",
+		"HOGE": "fuga",
+	}
+	expected := []*Config{
+		&Config{
+			Key:   "FOO",
+			Value: "bar",
+		},
+		&Config{
+			Key:   "BAZ",
+			Value: "1",
+		},
+		&Config{
+			Key:   "HOGE",
+			Value: "fuga",
+		},
+	}
+
+	configs := MapToConfigs(configMap)
+
+	if !reflect.DeepEqual(configs, expected) {
+		t.Errorf("Config list does not match. expected: %q, actual:%q", expected, configs)
+	}
+}
+
 func TestSaveAsYAML(t *testing.T) {
 	configs := []*Config{
 		&Config{


### PR DESCRIPTION
## WHY

It's troublesome to add encrypted text to local config file by hand.

## WHAT

Add `--add` flag to `encrypt` command. With `--add` flag, encrypted secret value is added to local config file automatically.

```bash
$ valec encrypt NAME=awesome --add secrets.yml
$ cat secrets.yml
- key: NAME
  value: AQECAHi1osu8IsEnPMo1...
```

This behavior is inspired by `travis encrypt FOO=bar --add key.name`.