### PR TITLE
Implement version command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ VERSION   := v0.1.0
 REVISION  := $(shell git rev-parse --short HEAD)
 
 SRCS      := $(shell find . -name '*.go' -type f)
-LDFLAGS   := -ldflags="-s -w -X \"main.Version=$(VERSION)\" -X \"main.Revision=$(REVISION)\""
+LDFLAGS   := -ldflags="-s -w -X \"github.com/dtan4/valec/version.Version=$(VERSION)\" -X \"github.com/dtan4/valec/version.Revision=$(REVISION)\""
 
 DIST_DIRS := find * -type d -exec
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/dtan4/valec/version"
+	"github.com/spf13/cobra"
+)
+
+// versionCmd represents the version command
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the version number",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println(version.String())
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(versionCmd)
+}

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,17 @@
+package version
+
+import (
+	"fmt"
+)
+
+var (
+	// Version represents version number
+	Version string
+	// Revision represents commit hash at built binary
+	Revision string
+)
+
+// String returns version string
+func String() string {
+	return fmt.Sprintf("Valec version %s, build %s", Version, Revision)
+}

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -1,0 +1,17 @@
+package version
+
+import (
+	"testing"
+)
+
+func TestString(t *testing.T) {
+	Version = "v0.1.0"
+	Revision = "abcd1234"
+
+	expected := "Valec version v0.1.0, build abcd1234"
+	actual := String()
+
+	if actual != expected {
+		t.Errorf("Version string does not match. expected: %q, actual: %q", expected, actual)
+	}
+}


### PR DESCRIPTION
## WHY

Currently there is no method to print binary version.

## WHAT

Implement `valec version` command to print version string.

```bash
$ valec version
Valec version v0.1.0, build 84e9d10
```