### PR TITLE
Add dry-run feature to sync command

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,21 @@ Synchronize secrets between local file and DynamoDB
 
 ```bash
 $ valec sync hoge.yaml
+No config will be deleted.
+
+1 configs of hoge namespace will be added.
+- PPAP
+1 configs of hoge namespace was successfully added.
+```
+
+If `--dry-run` flag is given, Valec does not modify DynamoDB table actually. This might be useful for CI use.
+
+```bash
+$ valec sync hoge.yaml --dry-run
+No config will be deleted.
+
+1 configs of hoge namespace will be added.
+- PPAP
 ```
 
 ## Development

--- a/cmd/flag_vars.go
+++ b/cmd/flag_vars.go
@@ -11,5 +11,6 @@ var (
 var (
 	configFile     string
 	dotenvTemplate string
+	dryRun         bool
 	override       bool
 )


### PR DESCRIPTION
## WHY

We would like to check the behavior of `valec sync` without real applying.

## WHAT

Add `--dry-run` flag to `valec sync` command. If `--dry-run` flag is given, Valec does not modify DynamoDB table actually and prints what configs will be changed.
This might be useful for CI use.

```bash
$ valec sync hoge.yaml --dry-run
No config will be deleted.

1 configs of hoge namespace will be added.
- PPAP
```