### PR TITLE
Prepare v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# [v0.1.1](https://github.com/dtan4/s3url/releases/tag/v0.1.1) (2016-12-01)
+
+## Features
+
+- Add dry-run feature to `valec sync` command [#10](https://github.com/dtan4/valec/pull/10)
+
 # [v0.1.0](https://github.com/dtan4/s3url/releases/tag/v0.1.0) (2016-11-30)
 
 Initial release.

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ VERSION   := v0.1.1
 REVISION  := $(shell git rev-parse --short HEAD)
 
 SRCS      := $(shell find . -name '*.go' -type f)
-LDFLAGS   := -ldflags="-s -w -X \"github.com/dtan4/valec/version.Version=$(VERSION)\" -X \"github.com/dtan4/valec/version.Revision=$(REVISION)\""
+LDFLAGS   := -ldflags="-s -w -X \"github.com/dtan4/valec/version.Version=$(VERSION)\" -X \"github.com/dtan4/valec/version.Revision=$(REVISION)\" -extldflags \"-static\""
 
 DIST_DIRS := find * -type d -exec
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME      := valec
-VERSION   := v0.1.0
+VERSION   := v0.1.1
 REVISION  := $(shell git rev-parse --short HEAD)
 
 SRCS      := $(shell find . -name '*.go' -type f)

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ clean:
 cross-build:
 	for os in darwin linux windows; do \
 		for arch in amd64 386; do \
-			GOOS=$$os GOARCH=$$arch CGO_ENABLED=0 go build $(LDFLAGS) -o dist/$$os-$$arch/$(NAME); \
+			GOOS=$$os GOARCH=$$arch go build -a -tags netgo -installsuffix netgo $(LDFLAGS) -o dist/$$os-$$arch/$(NAME); \
 		done; \
 	done
 


### PR DESCRIPTION
## WHAT

Prepare to release Valec v0.1.1.

Valec v0.1.0 binary does not run on vanilla Alpine Linux, because Valec v0.1.0 Linux 64bit binary is _dynamically_-linked. To fix this, I added some build flags to build _statically_-linked binaries.

## REF

- [golangで書いたアプリケーションのstatic link化 - okzkメモ](http://okzk.hatenablog.com/entry/2016/08/03/234738) (in Japanese)