### PR TITLE
Synchronize directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,12 +36,7 @@ vendor/
 /bin
 /dist
 
-/*.yaml
-!/glide.yaml
-
-/*.yml
-!/.travis.yml
-!/appveyor.yml
+/tmp
 
 /.env
 

--- a/README.md
+++ b/README.md
@@ -158,23 +158,34 @@ hoge
 
 Synchronize secrets between local file and DynamoDB
 
-```bash
-$ valec sync hoge.yaml
-No config will be deleted.
+Argument must be a directory that contains secret files. `hoge.yaml` will be synchronized to `hoge` namespace.
 
-1 configs of hoge namespace will be added.
-- PPAP
-1 configs of hoge namespace was successfully added.
+```bash
+$ ls secrets
+fuga.yaml       hoge.yaml
+
+$ valec sync secrets
+fuga
+  No config will be deleted.
+  No config will be added.
+hoge
+  No config will be deleted.
+  1 configs of unko namespace will be added.
+    + HOGE
+  1 configs of unko namespace were successfully added.
 ```
 
 If `--dry-run` flag is given, Valec does not modify DynamoDB table actually. This might be useful for CI use.
 
 ```bash
-$ valec sync hoge.yaml --dry-run
-No config will be deleted.
-
-1 configs of hoge namespace will be added.
-- PPAP
+$ valec sync configs --dry-run
+fuga
+  No config will be deleted.
+  No config will be added.
+hoge
+  No config will be deleted.
+  1 configs of unko namespace will be added.
+    + HOGE
 ```
 
 ## Development

--- a/cmd/flag_vars.go
+++ b/cmd/flag_vars.go
@@ -4,6 +4,7 @@ package cmd
 var (
 	debug     bool
 	keyAlias  string
+	noColor   bool
 	tableName string
 )
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -43,6 +43,7 @@ func init() {
 
 	RootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "Debug mode")
 	RootCmd.PersistentFlags().StringVar(&keyAlias, "key", defaultKeyAlias, "KMS key alias")
+	RootCmd.PersistentFlags().BoolVar(&noColor, "no-color", false, "Disable colorize output")
 	RootCmd.PersistentFlags().StringVar(&tableName, "table-name", defaultTableName, "DynamoDB table name")
 }
 

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -25,11 +25,6 @@ var syncCmd = &cobra.Command{
 		}
 		filename := args[0]
 
-		srcConfigs, err := lib.LoadConfigYAML(filename)
-		if err != nil {
-			return errors.Wrapf(err, "Failed to load configs. filename=%s", filename)
-		}
-
 		var namespace string
 
 		if len(args) == 1 {
@@ -38,51 +33,64 @@ var syncCmd = &cobra.Command{
 			namespace = args[1]
 		}
 
-		dstConfigs, err := aws.DynamoDB().ListConfigs(tableName, namespace)
-		if err != nil {
-			return errors.Wrapf(err, "Failed to retrieve configs. namespace=%s", namespace)
-		}
-
-		added, deleted := lib.CompareConfigList(srcConfigs, dstConfigs)
-
-		if len(deleted) > 0 {
-			fmt.Printf("%d configs of %s namespace will be deleted.\n", len(deleted), namespace)
-			for _, config := range deleted {
-				fmt.Printf("- %s\n", config.Key)
-			}
-
-			if !dryRun {
-				if err := aws.DynamoDB().Delete(tableName, namespace, deleted); err != nil {
-					return errors.Wrapf(err, "Failed to delete configs. namespace=%s", namespace)
-				}
-
-				fmt.Printf("%d configs of %s namespace were successfully deleted.\n", len(deleted), namespace)
-			}
-		} else {
-			fmt.Println("No config will be deleted.")
-		}
-
-		fmt.Println("")
-
-		if len(added) > 0 {
-			fmt.Printf("%d configs of %s namespace will be added.\n", len(added), namespace)
-			for _, config := range added {
-				fmt.Printf("- %s\n", config.Key)
-			}
-
-			if !dryRun {
-				if err := aws.DynamoDB().Insert(tableName, namespace, added); err != nil {
-					return errors.Wrapf(err, "Failed to insert configs. namespace=%s", namespace)
-				}
-
-				fmt.Printf("%d configs of %s namespace were successfully added.\n", len(added), namespace)
-			}
-		} else {
-			fmt.Println("No config will be added.")
+		if err := syncFile(filename, namespace); err != nil {
+			return errors.Wrapf(err, "Failed to synchronize configs. filename=%s", filename)
 		}
 
 		return nil
 	},
+}
+
+func syncFile(filename, namespace string) error {
+	srcConfigs, err := lib.LoadConfigYAML(filename)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to load configs. filename=%s", filename)
+	}
+
+	dstConfigs, err := aws.DynamoDB().ListConfigs(tableName, namespace)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to retrieve configs. namespace=%s", namespace)
+	}
+
+	added, deleted := lib.CompareConfigList(srcConfigs, dstConfigs)
+
+	if len(deleted) > 0 {
+		fmt.Printf("%d configs of %s namespace will be deleted.\n", len(deleted), namespace)
+		for _, config := range deleted {
+			fmt.Printf("- %s\n", config.Key)
+		}
+
+		if !dryRun {
+			if err := aws.DynamoDB().Delete(tableName, namespace, deleted); err != nil {
+				return errors.Wrapf(err, "Failed to delete configs. namespace=%s", namespace)
+			}
+
+			fmt.Printf("%d configs of %s namespace were successfully deleted.\n", len(deleted), namespace)
+		}
+	} else {
+		fmt.Println("No config will be deleted.")
+	}
+
+	fmt.Println("")
+
+	if len(added) > 0 {
+		fmt.Printf("%d configs of %s namespace will be added.\n", len(added), namespace)
+		for _, config := range added {
+			fmt.Printf("- %s\n", config.Key)
+		}
+
+		if !dryRun {
+			if err := aws.DynamoDB().Insert(tableName, namespace, added); err != nil {
+				return errors.Wrapf(err, "Failed to insert configs. namespace=%s", namespace)
+			}
+
+			fmt.Printf("%d configs of %s namespace were successfully added.\n", len(added), namespace)
+		}
+	} else {
+		fmt.Println("No config will be added.")
+	}
+
+	return nil
 }
 
 func init() {

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -70,7 +70,11 @@ func syncFile(filename string) error {
 	if len(deleted) > 0 {
 		fmt.Printf("%  d configs of %s namespace will be deleted.\n", len(deleted), namespace)
 		for _, config := range deleted {
-			red.Printf("    - %s\n", config.Key)
+			if noColor {
+				fmt.Printf("    - %s\n", config.Key)
+			} else {
+				red.Printf("    - %s\n", config.Key)
+			}
 		}
 
 		if !dryRun {
@@ -87,7 +91,11 @@ func syncFile(filename string) error {
 	if len(added) > 0 {
 		fmt.Printf("  %d configs of %s namespace will be added.\n", len(added), namespace)
 		for _, config := range added {
-			green.Printf("    + %s\n", config.Key)
+			if noColor {
+				fmt.Printf("    + %s\n", config.Key)
+			} else {
+				green.Printf("    + %s\n", config.Key)
+			}
 		}
 
 		if !dryRun {

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -25,15 +25,7 @@ var syncCmd = &cobra.Command{
 		}
 		filename := args[0]
 
-		var namespace string
-
-		if len(args) == 1 {
-			namespace = yamlExtRegexp.ReplaceAllString(filepath.Base(filename), "")
-		} else {
-			namespace = args[1]
-		}
-
-		if err := syncFile(filename, namespace); err != nil {
+		if err := syncFile(filename); err != nil {
 			return errors.Wrapf(err, "Failed to synchronize configs. filename=%s", filename)
 		}
 
@@ -41,7 +33,9 @@ var syncCmd = &cobra.Command{
 	},
 }
 
-func syncFile(filename, namespace string) error {
+func syncFile(filename string) error {
+	namespace := yamlExtRegexp.ReplaceAllString(filepath.Base(filename), "")
+
 	srcConfigs, err := lib.LoadConfigYAML(filename)
 	if err != nil {
 		return errors.Wrapf(err, "Failed to load configs. filename=%s", filename)

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -50,6 +50,7 @@ var syncCmd = &cobra.Command{
 
 func syncFile(filename string) error {
 	namespace := yamlExtRegexp.ReplaceAllString(filepath.Base(filename), "")
+	fmt.Println(namespace)
 
 	srcConfigs, err := lib.LoadConfigYAML(filename)
 	if err != nil {
@@ -64,9 +65,9 @@ func syncFile(filename string) error {
 	added, deleted := lib.CompareConfigList(srcConfigs, dstConfigs)
 
 	if len(deleted) > 0 {
-		fmt.Printf("%d configs of %s namespace will be deleted.\n", len(deleted), namespace)
+		fmt.Printf("%  d configs of %s namespace will be deleted.\n", len(deleted), namespace)
 		for _, config := range deleted {
-			fmt.Printf("- %s\n", config.Key)
+			fmt.Printf("    - %s\n", config.Key)
 		}
 
 		if !dryRun {
@@ -74,18 +75,16 @@ func syncFile(filename string) error {
 				return errors.Wrapf(err, "Failed to delete configs. namespace=%s", namespace)
 			}
 
-			fmt.Printf("%d configs of %s namespace were successfully deleted.\n", len(deleted), namespace)
+			fmt.Printf("  %d configs of %s namespace were successfully deleted.\n", len(deleted), namespace)
 		}
 	} else {
-		fmt.Println("No config will be deleted.")
+		fmt.Println("  No config will be deleted.")
 	}
 
-	fmt.Println("")
-
 	if len(added) > 0 {
-		fmt.Printf("%d configs of %s namespace will be added.\n", len(added), namespace)
+		fmt.Printf("  %d configs of %s namespace will be added.\n", len(added), namespace)
 		for _, config := range added {
-			fmt.Printf("- %s\n", config.Key)
+			fmt.Printf("    + %s\n", config.Key)
 		}
 
 		if !dryRun {
@@ -93,10 +92,10 @@ func syncFile(filename string) error {
 				return errors.Wrapf(err, "Failed to insert configs. namespace=%s", namespace)
 			}
 
-			fmt.Printf("%d configs of %s namespace were successfully added.\n", len(added), namespace)
+			fmt.Printf("  %d configs of %s namespace were successfully added.\n", len(added), namespace)
 		}
 	} else {
-		fmt.Println("No config will be added.")
+		fmt.Println("  No config will be added.")
 	}
 
 	return nil

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/dtan4/valec/aws"
 	"github.com/dtan4/valec/lib"
+	"github.com/fatih/color"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -63,11 +64,13 @@ func syncFile(filename string) error {
 	}
 
 	added, deleted := lib.CompareConfigList(srcConfigs, dstConfigs)
+	red := color.New(color.FgRed)
+	green := color.New(color.FgGreen)
 
 	if len(deleted) > 0 {
 		fmt.Printf("%  d configs of %s namespace will be deleted.\n", len(deleted), namespace)
 		for _, config := range deleted {
-			fmt.Printf("    - %s\n", config.Key)
+			red.Printf("    - %s\n", config.Key)
 		}
 
 		if !dryRun {
@@ -84,7 +87,7 @@ func syncFile(filename string) error {
 	if len(added) > 0 {
 		fmt.Printf("  %d configs of %s namespace will be added.\n", len(added), namespace)
 		for _, config := range added {
-			fmt.Printf("    + %s\n", config.Key)
+			green.Printf("    + %s\n", config.Key)
 		}
 
 		if !dryRun {

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: a5b49a633fd49dc7bcab4a9571e718adcb89df9801620ada098225cb45325ba8
-updated: 2016-12-02T14:58:22.023133762+09:00
+updated: 2016-12-02T15:25:47.606764506+09:00
 imports:
 - name: github.com/aws/aws-sdk-go
   version: 918c42e2bcdb277aa821401c906e88254501bdf4
@@ -39,12 +39,20 @@ imports:
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 - name: github.com/jmespath/go-jmespath
   version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
+- name: github.com/mattn/go-colorable
+  version: d228849504861217f796da67fae4f6e347643f15
+- name: github.com/mattn/go-isatty
+  version: 30a891c33c7cde7b02a981314b4228ec99380cca
 - name: github.com/pkg/errors
   version: 645ef00459ed84a119197bfb8d8205042c6df63d
 - name: github.com/spf13/cobra
   version: 9495bc009a56819bdb0ddbc1a373e29c140bc674
 - name: github.com/spf13/pflag
   version: 5ccb023bc27df288a957c5e994cd44fd19619465
+- name: golang.org/x/sys
+  version: d5645953809d8b4752afb2c3224b1f1ad73dfa70
+  subpackages:
+  - unix
 - name: gopkg.in/yaml.v2
   version: e4d366fc3c7938e2958e662b4258c7a89e1f0e3e
 testImports: []

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
-hash: 41a175f33460d34905167f99ab4969f182d4c1dc3580e5282572e335082b21b8
-updated: 2016-11-24T18:59:43.199276008+09:00
+hash: a5b49a633fd49dc7bcab4a9571e718adcb89df9801620ada098225cb45325ba8
+updated: 2016-12-02T14:58:22.023133762+09:00
 imports:
 - name: github.com/aws/aws-sdk-go
-  version: 4a6ff995f57ee4f8994db17ae83f01a9c9cc2274
+  version: 918c42e2bcdb277aa821401c906e88254501bdf4
   subpackages:
   - aws
   - aws/awserr
@@ -31,8 +31,10 @@ imports:
   - service/dynamodb
   - service/kms
   - service/sts
+- name: github.com/fatih/color
+  version: dea9d3a26a087187530244679c1cfb3a42937794
 - name: github.com/go-ini/ini
-  version: 2ba15ac2dc9cdf88c110ec2dc0ced7fa45f5678c
+  version: 6e4869b434bd001f6983749881c7ead3545887d8
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 - name: github.com/jmespath/go-jmespath
@@ -44,5 +46,5 @@ imports:
 - name: github.com/spf13/pflag
   version: 5ccb023bc27df288a957c5e994cd44fd19619465
 - name: gopkg.in/yaml.v2
-  version: a5b47d31c556af34a302ce5d659e6fea44d90de0
+  version: e4d366fc3c7938e2958e662b4258c7a89e1f0e3e
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -11,3 +11,5 @@ import:
 - package: gopkg.in/yaml.v2
 - package: github.com/pkg/errors
   version: ~0.8.0
+- package: github.com/fatih/color
+  version: ~1.1.0


### PR DESCRIPTION
## WHY

We have to write shell script to synchronize multiple directory. This is troublesome.

```bash
for f in `find secrets -type f -name '*.yaml'`; do
  valec sync $f
done
```

## WHAT

Change `valec sync` argument from a single file to directory. Now `valec sync` scans all files in the given directory and synchronize them.