### PR TITLE
Add --region flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,16 @@ secrets/hoge.yaml
 Failed to validate configs. filename=tmp/hoge.yaml: Some configs are invalid.
 ```
 
+### Common flags
+
+|Flag|Description|Default|
+|---|---|---|
+|`--debug`|Debug mode|`false`|
+|`--key KEY`|KMS key alias|`valec`|
+|`--no-color`|Disable colorized output|`false`|
+|`--table-name`|DynamoDB table name|`valec`|
+|`--region`|AWS Region|(empty)|
+
 ## Development
 
 Retrieve this repository and build using `make`.

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -7,31 +7,37 @@ import (
 	kmsapi "github.com/aws/aws-sdk-go/service/kms"
 	"github.com/dtan4/valec/aws/dynamodb"
 	"github.com/dtan4/valec/aws/kms"
+	"github.com/pkg/errors"
 )
 
 var (
-	dynamoDBClient *dynamodb.Client
-	kmsClient      *kms.Client
+	// DynamoDB represents DynamoDB API client
+	DynamoDB *dynamodb.Client
+	// KMS represents KMS API client
+	KMS *kms.Client
 )
 
-// DynamoDB returns DynamoDB API Client and create new one if it does not exit
-func DynamoDB() *dynamodb.Client {
-	api := dynamodbapi.New(session.New(), &aws.Config{})
+// Initialize initializes AWS API clients
+func Initialize(region string) error {
+	var (
+		sess *session.Session
+		err  error
+	)
 
-	if dynamoDBClient == nil {
-		dynamoDBClient = dynamodb.NewClient(api)
+	if region == "" {
+		sess, err = session.NewSession()
+		if err != nil {
+			return errors.Wrap(err, "Failed to create new AWS session.")
+		}
+	} else {
+		sess, err = session.NewSession(&aws.Config{Region: aws.String(region)})
+		if err != nil {
+			return errors.Wrap(err, "Failed to create new AWS session.")
+		}
 	}
 
-	return dynamoDBClient
-}
+	DynamoDB = dynamodb.NewClient(dynamodbapi.New(sess))
+	KMS = kms.NewClient(kmsapi.New(sess))
 
-// KMS returns KMS API Client and create new one if it does not exist
-func KMS() *kms.Client {
-	api := kmsapi.New(session.New(), &aws.Config{})
-
-	if kmsClient == nil {
-		kmsClient = kms.NewClient(api)
-	}
-
-	return kmsClient
+	return nil
 }

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -1,6 +1,10 @@
 package aws
 
 import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	dynamodbapi "github.com/aws/aws-sdk-go/service/dynamodb"
+	kmsapi "github.com/aws/aws-sdk-go/service/kms"
 	"github.com/dtan4/valec/aws/dynamodb"
 	"github.com/dtan4/valec/aws/kms"
 )
@@ -10,10 +14,12 @@ var (
 	kmsClient      *kms.Client
 )
 
-// DynampDB returns DynamoDB API Client and create new one if it does not exit
+// DynamoDB returns DynamoDB API Client and create new one if it does not exit
 func DynamoDB() *dynamodb.Client {
+	api := dynamodbapi.New(session.New(), &aws.Config{})
+
 	if dynamoDBClient == nil {
-		dynamoDBClient = dynamodb.NewClient()
+		dynamoDBClient = dynamodb.NewClient(api)
 	}
 
 	return dynamoDBClient
@@ -21,8 +27,10 @@ func DynamoDB() *dynamodb.Client {
 
 // KMS returns KMS API Client and create new one if it does not exist
 func KMS() *kms.Client {
+	api := kmsapi.New(session.New(), &aws.Config{})
+
 	if kmsClient == nil {
-		kmsClient = kms.NewClient()
+		kmsClient = kms.NewClient(api)
 	}
 
 	return kmsClient

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -22,7 +22,7 @@ var dumpCmd = &cobra.Command{
 		}
 		namespace := args[0]
 
-		configs, err := aws.DynamoDB().ListConfigs(tableName, namespace)
+		configs, err := aws.DynamoDB.ListConfigs(tableName, namespace)
 		if err != nil {
 			return errors.Wrap(err, "Failed to retrieve configs.")
 		}
@@ -43,7 +43,7 @@ var dumpCmd = &cobra.Command{
 
 func dumpAll(configs []*lib.Config) error {
 	for _, config := range configs {
-		plainValue, err := aws.KMS().DecryptBase64(config.Key, config.Value)
+		plainValue, err := aws.KMS.DecryptBase64(config.Key, config.Value)
 		if err != nil {
 			return errors.Wrap(err, "Failed to decrypt value.")
 		}
@@ -83,7 +83,7 @@ func dumpWithTemplate(configs []*lib.Config) error {
 		if override || value == "" {
 			v, ok := configMap[key]
 			if ok {
-				plainValue, err := aws.KMS().DecryptBase64(key, v)
+				plainValue, err := aws.KMS.DecryptBase64(key, v)
 				if err != nil {
 					return errors.Wrap(err, "Failed to decrypt value.")
 				}

--- a/cmd/encrypt.go
+++ b/cmd/encrypt.go
@@ -27,7 +27,7 @@ var encryptCmd = &cobra.Command{
 		}
 		key, value := ss[0], ss[1]
 
-		cipherText, err := aws.KMS().EncryptBase64(keyAlias, key, value)
+		cipherText, err := aws.KMS.EncryptBase64(keyAlias, key, value)
 		if err != nil {
 			return errors.Wrapf(err, "Failed to encrypt.")
 		}

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -25,7 +25,7 @@ Stored secrets are consumed as environment variables.
 		}
 		namespace := args[0]
 
-		configs, err := aws.DynamoDB().ListConfigs(tableName, namespace)
+		configs, err := aws.DynamoDB.ListConfigs(tableName, namespace)
 		if err != nil {
 			return errors.Wrapf(err, "Failed to load configs from DynamoDB. namespace=%s", namespace)
 		}
@@ -33,7 +33,7 @@ Stored secrets are consumed as environment variables.
 		envs := os.Environ()
 
 		for _, config := range configs {
-			plainValue, err := aws.KMS().DecryptBase64(config.Key, config.Value)
+			plainValue, err := aws.KMS.DecryptBase64(config.Key, config.Value)
 			if err != nil {
 				return errors.Wrapf(err, "Failed to decrypt value. key=%q, value=%q", config.Key, config.Value)
 			}

--- a/cmd/flag_vars.go
+++ b/cmd/flag_vars.go
@@ -6,6 +6,7 @@ var (
 	keyAlias  string
 	noColor   bool
 	tableName string
+	region    string
 )
 
 // command-specific flag variable

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -18,7 +18,7 @@ These resources will be created:
   - KMS key and alias
   - DynamoDB table`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		keyExists, err := aws.KMS().KeyExists(keyAlias)
+		keyExists, err := aws.KMS.KeyExists(keyAlias)
 		if err != nil {
 			return errors.Wrap(err, "Failed to check existence of key alias.")
 		}
@@ -26,19 +26,19 @@ These resources will be created:
 		if keyExists {
 			fmt.Printf("Key %q alreadly exists.\n", keyAlias)
 		} else {
-			keyID, err := aws.KMS().CreateKey()
+			keyID, err := aws.KMS.CreateKey()
 			if err != nil {
 				return errors.Wrap(err, "Failed to create new key.")
 			}
 
-			if err := aws.KMS().CreateKeyAlias(keyID, keyAlias); err != nil {
+			if err := aws.KMS.CreateKeyAlias(keyID, keyAlias); err != nil {
 				return errors.Wrap(err, "Failed to attach alias to key.")
 			}
 
 			fmt.Printf("Key %s successfully created!\n", keyAlias)
 		}
 
-		tableExists, err := aws.DynamoDB().TableExists(tableName)
+		tableExists, err := aws.DynamoDB.TableExists(tableName)
 		if err != nil {
 			return errors.Wrap(err, "Failed to check existence of DynamoDB table.")
 		}
@@ -46,7 +46,7 @@ These resources will be created:
 		if tableExists {
 			fmt.Printf("DynamoDB table %q alreadly exists.\n", tableName)
 		} else {
-			if err := aws.DynamoDB().CreateTable(tableName); err != nil {
+			if err := aws.DynamoDB.CreateTable(tableName); err != nil {
 				return errors.Wrapf(err, "Failed to create DynamoDB table. table=%s", tableName)
 			}
 

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -33,7 +33,7 @@ Encrypted values are decrypted and printed as plain text.`,
 			}
 			namespace := args[0]
 
-			configs, err = aws.DynamoDB().ListConfigs(tableName, namespace)
+			configs, err = aws.DynamoDB.ListConfigs(tableName, namespace)
 			if err != nil {
 				return errors.Wrapf(err, "Failed to load configs from DynamoDB. namespace=%s", namespace)
 			}
@@ -47,7 +47,7 @@ Encrypted values are decrypted and printed as plain text.`,
 		longestLength := longestKeyLength(configs)
 
 		for _, config := range configs {
-			plainValue, err := aws.KMS().DecryptBase64(config.Key, config.Value)
+			plainValue, err := aws.KMS.DecryptBase64(config.Key, config.Value)
 			if err != nil {
 				return errors.Wrapf(err, "Failed to decrypt value. key=%q, value=%q", config.Key, config.Value)
 			}

--- a/cmd/namespaces.go
+++ b/cmd/namespaces.go
@@ -13,7 +13,7 @@ var namespacesCmd = &cobra.Command{
 	Use:   "namespaces",
 	Short: "List all namespaces",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		namespaces, err := aws.DynamoDB().ListNamespaces(tableName)
+		namespaces, err := aws.DynamoDB.ListNamespaces(tableName)
 		if err != nil {
 			return errors.Wrap(err, "Failed to retrieve namespaces.")
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/dtan4/valec/aws"
 	"github.com/spf13/cobra"
 )
 
@@ -28,6 +29,15 @@ Valec enables you to manage application secrets in your favorite VCS.`,
 // Execute adds all child commands to the root command sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
+	if err := aws.Initialize(region); err != nil {
+		if debug {
+			fmt.Printf("%+v\n", err)
+		} else {
+			fmt.Println(err)
+		}
+		os.Exit(-1)
+	}
+
 	if err := RootCmd.Execute(); err != nil {
 		if debug {
 			fmt.Printf("%+v\n", err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,6 +45,7 @@ func init() {
 	RootCmd.PersistentFlags().StringVar(&keyAlias, "key", defaultKeyAlias, "KMS key alias")
 	RootCmd.PersistentFlags().BoolVar(&noColor, "no-color", false, "Disable colorize output")
 	RootCmd.PersistentFlags().StringVar(&tableName, "table-name", defaultTableName, "DynamoDB table name")
+	RootCmd.PersistentFlags().StringVar(&region, "region", "", "AWS region")
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -53,7 +53,7 @@ func init() {
 
 	RootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "Debug mode")
 	RootCmd.PersistentFlags().StringVar(&keyAlias, "key", defaultKeyAlias, "KMS key alias")
-	RootCmd.PersistentFlags().BoolVar(&noColor, "no-color", false, "Disable colorize output")
+	RootCmd.PersistentFlags().BoolVar(&noColor, "no-color", false, "Disable colorized output")
 	RootCmd.PersistentFlags().StringVar(&tableName, "table-name", defaultTableName, "DynamoDB table name")
 	RootCmd.PersistentFlags().StringVar(&region, "region", "", "AWS region")
 }

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -58,7 +58,7 @@ func syncFile(filename string) error {
 		return errors.Wrapf(err, "Failed to load configs. filename=%s", filename)
 	}
 
-	dstConfigs, err := aws.DynamoDB().ListConfigs(tableName, namespace)
+	dstConfigs, err := aws.DynamoDB.ListConfigs(tableName, namespace)
 	if err != nil {
 		return errors.Wrapf(err, "Failed to retrieve configs. namespace=%s", namespace)
 	}
@@ -78,7 +78,7 @@ func syncFile(filename string) error {
 		}
 
 		if !dryRun {
-			if err := aws.DynamoDB().Delete(tableName, namespace, deleted); err != nil {
+			if err := aws.DynamoDB.Delete(tableName, namespace, deleted); err != nil {
 				return errors.Wrapf(err, "Failed to delete configs. namespace=%s", namespace)
 			}
 
@@ -99,7 +99,7 @@ func syncFile(filename string) error {
 		}
 
 		if !dryRun {
-			if err := aws.DynamoDB().Insert(tableName, namespace, added); err != nil {
+			if err := aws.DynamoDB.Insert(tableName, namespace, added); err != nil {
 				return errors.Wrapf(err, "Failed to insert configs. namespace=%s", namespace)
 			}
 

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -58,7 +58,7 @@ func validateFile(filename string) error {
 	red := color.New(color.FgRed)
 
 	for _, config := range configs {
-		if _, err := aws.KMS().DecryptBase64(config.Key, config.Value); err != nil {
+		if _, err := aws.KMS.DecryptBase64(config.Key, config.Value); err != nil {
 			red.Printf("  Config value is invalid. Please try `valec encrypt`. key=%s\n", config.Key)
 			hasError = true
 		}


### PR DESCRIPTION
## WHY

`AWS_REGION` must be set even if the owner is in EC2 instance with IAM role. Sometimes it is difficult to pass environment variables at execution time, like via SSH.

## WHAT

Add `--region` flag to specify region at execution time.

In addition, AWS service clients now uses interfaces. Thanks to this, we can write tests of each AWS service client.