### PR TITLE
Detect 'updated' changes

### DIFF
--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -94,9 +94,10 @@ func syncFile(filename, parentNamespace string) error {
 		return errors.Wrapf(err, "Failed to retrieve secrets. namespace=%s", namespace)
 	}
 
-	added, deleted := srcSecrets.CompareList(dstSecrets)
+	added, updated, deleted := srcSecrets.CompareList(dstSecrets)
 	red := color.New(color.FgRed)
 	green := color.New(color.FgGreen)
+	yellow := color.New(color.FgYellow)
 
 	if len(deleted) > 0 {
 		fmt.Printf("%  d secrets will be deleted.\n", len(deleted))
@@ -117,6 +118,27 @@ func syncFile(filename, parentNamespace string) error {
 		}
 	} else {
 		fmt.Println("  No secret will be deleted.")
+	}
+
+	if len(updated) > 0 {
+		fmt.Printf("  %d secrets will be updated.\n", len(updated))
+		for _, secret := range updated {
+			if noColor {
+				fmt.Printf("    + %s\n", secret.Key)
+			} else {
+				yellow.Printf("    + %s\n", secret.Key)
+			}
+		}
+
+		if !dryRun {
+			if err := aws.DynamoDB.Insert(tableName, namespace, updated); err != nil {
+				return errors.Wrapf(err, "Failed to insert secrets. namespace=%s")
+			}
+
+			fmt.Printf("  %d secrets were successfully updated.\n", len(updated))
+		}
+	} else {
+		fmt.Println("  No secret will be updated.")
 	}
 
 	if len(added) > 0 {

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -116,8 +116,6 @@ func syncFile(filename, parentNamespace string) error {
 
 			fmt.Printf("  %d secrets were successfully deleted.\n", len(deleted))
 		}
-	} else {
-		fmt.Println("  No secret will be deleted.")
 	}
 
 	if len(updated) > 0 {
@@ -137,8 +135,6 @@ func syncFile(filename, parentNamespace string) error {
 
 			fmt.Printf("  %d secrets were successfully updated.\n", len(updated))
 		}
-	} else {
-		fmt.Println("  No secret will be updated.")
 	}
 
 	if len(added) > 0 {
@@ -158,8 +154,6 @@ func syncFile(filename, parentNamespace string) error {
 
 			fmt.Printf("  %d secrets were successfully added.\n", len(added))
 		}
-	} else {
-		fmt.Println("  No secret will be added.")
 	}
 
 	return nil

--- a/secret/secret.go
+++ b/secret/secret.go
@@ -51,25 +51,26 @@ func (ss Secrets) Swap(i, j int) {
 }
 
 // CompareList compares two secret lists and returns the differences between them
-func (ss Secrets) CompareList(target Secrets) (Secrets, Secrets) {
-	added, deleted := Secrets{}, Secrets{}
+func (ss Secrets) CompareList(target Secrets) (added, updated, deleted Secrets) {
 	srcMap, dstMap := ss.ListToMap(), target.ListToMap()
 
 	for _, c := range ss {
-		v, ok := dstMap[c.Key]
-		if !ok || v != c.Value {
+		_, ok := dstMap[c.Key]
+		if !ok {
 			added = append(added, c)
 		}
 	}
 
 	for _, c := range target {
 		v, ok := srcMap[c.Key]
-		if !ok || v != c.Value {
+		if !ok {
 			deleted = append(deleted, c)
+		} else if v != c.Value {
+			updated = append(updated, c)
 		}
 	}
 
-	return added, deleted
+	return added, updated, deleted
 }
 
 // ListToMap converts secret list to map

--- a/secret/secret.go
+++ b/secret/secret.go
@@ -51,11 +51,11 @@ func (ss Secrets) Swap(i, j int) {
 }
 
 // CompareList compares two secret lists and returns the differences between them
-func (ss Secrets) CompareList(target Secrets) (added, updated, deleted Secrets) {
-	srcMap, dstMap := ss.ListToMap(), target.ListToMap()
+func (ss Secrets) CompareList(old Secrets) (added, updated, deleted Secrets) {
+	newMap, oldMap := ss.ListToMap(), old.ListToMap()
 
 	for _, c := range ss {
-		v, ok := dstMap[c.Key]
+		v, ok := oldMap[c.Key]
 		if !ok {
 			added = append(added, c)
 		} else if v != c.Value {
@@ -63,8 +63,8 @@ func (ss Secrets) CompareList(target Secrets) (added, updated, deleted Secrets) 
 		}
 	}
 
-	for _, c := range target {
-		_, ok := srcMap[c.Key]
+	for _, c := range old {
+		_, ok := newMap[c.Key]
 		if !ok {
 			deleted = append(deleted, c)
 		}

--- a/secret/secret.go
+++ b/secret/secret.go
@@ -55,18 +55,18 @@ func (ss Secrets) CompareList(target Secrets) (added, updated, deleted Secrets) 
 	srcMap, dstMap := ss.ListToMap(), target.ListToMap()
 
 	for _, c := range ss {
-		_, ok := dstMap[c.Key]
+		v, ok := dstMap[c.Key]
 		if !ok {
 			added = append(added, c)
+		} else if v != c.Value {
+			updated = append(updated, c)
 		}
 	}
 
 	for _, c := range target {
-		v, ok := srcMap[c.Key]
+		_, ok := srcMap[c.Key]
 		if !ok {
 			deleted = append(deleted, c)
-		} else if v != c.Value {
-			updated = append(updated, c)
 		}
 	}
 

--- a/secret/secret_test.go
+++ b/secret/secret_test.go
@@ -124,7 +124,7 @@ func TestSwap(t *testing.T) {
 }
 
 func TestCompareList(t *testing.T) {
-	src := Secrets{
+	newSecrets := Secrets{
 		&Secret{
 			Key:   "FOO",
 			Value: "bar",
@@ -138,7 +138,7 @@ func TestCompareList(t *testing.T) {
 			Value: "fuga",
 		},
 	}
-	dst := Secrets{
+	oldSecrets := Secrets{
 		&Secret{
 			Key:   "FOO",
 			Value: "baz",
@@ -180,7 +180,7 @@ func TestCompareList(t *testing.T) {
 		},
 	}
 
-	added, updated, deleted := src.CompareList(dst)
+	added, updated, deleted := newSecrets.CompareList(oldSecrets)
 
 	if !secretListsEqual(added, expectAdded) {
 		t.Errorf("Returned added secrets are wrong. expected: %s, actual: %s", stringifySecretList(expectAdded), stringifySecretList(added))

--- a/secret/secret_test.go
+++ b/secret/secret_test.go
@@ -159,19 +159,17 @@ func TestCompareList(t *testing.T) {
 
 	expectAdded := Secrets{
 		&Secret{
-			Key:   "FOO",
-			Value: "bar",
-		},
-		&Secret{
 			Key:   "HOGE",
 			Value: "fuga",
 		},
 	}
-	expectDeleted := Secrets{
+	expectUpdated := Secrets{
 		&Secret{
 			Key:   "FOO",
 			Value: "baz",
 		},
+	}
+	expectDeleted := Secrets{
 		&Secret{
 			Key:   "QUX",
 			Value: "true",
@@ -182,10 +180,14 @@ func TestCompareList(t *testing.T) {
 		},
 	}
 
-	added, deleted := src.CompareList(dst)
+	added, updated, deleted := src.CompareList(dst)
 
 	if !secretListsEqual(added, expectAdded) {
 		t.Errorf("Returned added secrets are wrong. expected: %s, actual: %s", stringifySecretList(expectAdded), stringifySecretList(added))
+	}
+
+	if !secretListsEqual(updated, expectUpdated) {
+		t.Errorf("Returned updated secrets are wrong. expected: %s, actual: %s", stringifySecretList(expectUpdated), stringifySecretList(updated))
 	}
 
 	if !secretListsEqual(deleted, expectDeleted) {

--- a/secret/secret_test.go
+++ b/secret/secret_test.go
@@ -166,7 +166,7 @@ func TestCompareList(t *testing.T) {
 	expectUpdated := Secrets{
 		&Secret{
 			Key:   "FOO",
-			Value: "baz",
+			Value: "bar",
 		},
 	}
 	expectDeleted := Secrets{


### PR DESCRIPTION
## WHY

Currently `valec sync` returns 'added' and 'deleted' secrets only. If some secrets are 'updated', there will be shown at both 'added' and 'deleted'.

## WHAT

Detect 'updated' changes correctly.