### PR TITLE
Show error if the given namespace does not exist

### DIFF
--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -27,6 +27,10 @@ var dumpCmd = &cobra.Command{
 			return errors.Wrap(err, "Failed to retrieve secrets.")
 		}
 
+		if len(secrets) == 0 {
+			return errors.Errorf("Namespace %s does not exist.", namespace)
+		}
+
 		if dotenvTemplate == "" {
 			if err := dumpAll(secrets); err != nil {
 				return errors.Wrap(err, "Failed to dump all secrets.")

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -37,6 +37,10 @@ Encrypted values are decrypted and printed as plain text.`,
 			if err != nil {
 				return errors.Wrapf(err, "Failed to load secrets from DynamoDB. namespace=%s", namespace)
 			}
+
+			if len(secrets) == 0 {
+				return errors.Errorf("Namespace %s does not exist.", namespace)
+			}
 		} else {
 			secrets, err = secret.LoadFromYAML(secretFile)
 			if err != nil {


### PR DESCRIPTION
## WHY

Currently `valec dump` and `valec list` shows no error if the given namespace does not exist on DynamoDB.

## WHAT

Show error message.