### PR TITLE
Specify keys to use at `valec exec`

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,10 @@ HOGE=fuga
 With `-k KEYS` flag, you can use secrets you specified only.
 
 ```bash
-$ valec exec hoge -k HOGE env
+$ valec exec hoge -k HOGE,FOO env
+...
 HOGE=fuga
+FOO=bar
 ```
 
 ### `valec init`

--- a/README.md
+++ b/README.md
@@ -119,6 +119,13 @@ $ valec exec hoge env | grep HOGE
 HOGE=fuga
 ```
 
+With `-k KEYS` flag, you can use secrets you specified only.
+
+```bash
+$ valec exec hoge -k HOGE env
+HOGE=fuga
+```
+
 ### `valec init`
 
 Initialize Valec environment

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -73,5 +73,5 @@ Stored secrets are consumed as environment variables.
 func init() {
 	RootCmd.AddCommand(execCmd)
 
-	execCmd.Flags().StringVarP(&keys, "keys", "k", "", "Secret keys to fetch")
+	execCmd.Flags().StringVarP(&keys, "keys", "k", "", "Secret keys to fetch (KEY1,KEY2,...)")
 }

--- a/cmd/flag_vars.go
+++ b/cmd/flag_vars.go
@@ -11,6 +11,7 @@ var (
 
 // command-specific flag variable
 var (
+	keys           string
 	secretFile     string
 	dotenvTemplate string
 	dryRun         bool


### PR DESCRIPTION
## WHY

Sometimes we want to use a part of stored secrets.

## WHAT

Add `-k KEYS` flag to `valec exec` to specify keys to use.