### PR TITLE
Dump values as quoted string

### DIFF
--- a/cmd/flag_vars.go
+++ b/cmd/flag_vars.go
@@ -16,4 +16,5 @@ var (
 	dryRun         bool
 	output         string
 	override       bool
+	quote          bool
 )


### PR DESCRIPTION
## WHY

Sometimes we want to dump secret values as quoted string, e.g. `terraform.tfvars`

```
awesome_password="awesomepassword"
great_service_url="https://great-svc.example.com/"
```

### WHAT

Add `-q` flag to `valec dump`