### PR TITLE
Validate nested secrets

### DIFF
--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -2,8 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 
 	"github.com/dtan4/valec/aws"
 	"github.com/dtan4/valec/secret"
@@ -23,22 +21,19 @@ var validateCmd = &cobra.Command{
 		}
 		dirname := args[0]
 
-		if err := filepath.Walk(dirname, validateWalkFunc); err != nil {
-			return errors.Wrapf(err, "Failed to validate files in directory. dirname=%s", dirname)
+		files, err := util.ListYAMLFiles(dirname)
+		if err != nil {
+			return errors.Wrapf(err, "Failed to read directory. dirname=%s", dirname)
 		}
 
-		fmt.Println("All secrets are valid.")
+		for _, file := range files {
+			if err := validateFile(file); err != nil {
+				return errors.Wrapf(err, "Failed to validate file. filename=%s", file)
+			}
+		}
 
 		return nil
 	},
-}
-
-func validateWalkFunc(path string, info os.FileInfo, e error) error {
-	if !util.IsSecretFile(path) {
-		return nil
-	}
-
-	return validateFile(path)
 }
 
 func validateFile(filename string) error {

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -47,6 +47,7 @@ func validateFile(filename string) error {
 	}
 
 	hasError := false
+	green := color.New(color.FgGreen)
 	red := color.New(color.FgRed)
 
 	for _, secret := range secrets {
@@ -59,6 +60,8 @@ func validateFile(filename string) error {
 	if hasError {
 		return errors.New("Some secrets are invalid.")
 	}
+
+	green.Println("  All secrets are valid.")
 
 	return nil
 }

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -2,12 +2,10 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
-	"path/filepath"
-	"strings"
 
 	"github.com/dtan4/valec/aws"
 	"github.com/dtan4/valec/secret"
+	"github.com/dtan4/valec/util"
 	"github.com/fatih/color"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -23,20 +21,14 @@ var validateCmd = &cobra.Command{
 		}
 		dirname := args[0]
 
-		files, err := ioutil.ReadDir(dirname)
+		files, err := util.ListYAMLFiles(dirname)
 		if err != nil {
 			return errors.Wrapf(err, "Failed to read directory. dirname=%s", dirname)
 		}
 
 		for _, file := range files {
-			if strings.HasPrefix(file.Name(), ".") || !yamlExtRegexp.Match([]byte(file.Name())) {
-				continue
-			}
-
-			filename := filepath.Join(dirname, file.Name())
-
-			if err := validateFile(filename); err != nil {
-				return errors.Wrapf(err, "Failed to validate secrets. filename=%s", filename)
+			if err := validateFile(file); err != nil {
+				return errors.Wrapf(err, "Failed to validate secrets. filename=%s", file)
 			}
 		}
 

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/dtan4/valec/aws"
 	"github.com/dtan4/valec/secret"
@@ -21,21 +23,22 @@ var validateCmd = &cobra.Command{
 		}
 		dirname := args[0]
 
-		files, err := util.ListYAMLFiles(dirname)
-		if err != nil {
-			return errors.Wrapf(err, "Failed to read directory. dirname=%s", dirname)
-		}
-
-		for _, file := range files {
-			if err := validateFile(file); err != nil {
-				return errors.Wrapf(err, "Failed to validate secrets. filename=%s", file)
-			}
+		if err := filepath.Walk(dirname, validateWalkFunc); err != nil {
+			return errors.Wrapf(err, "Failed to validate files in directory. dirname=%s", dirname)
 		}
 
 		fmt.Println("All secrets are valid.")
 
 		return nil
 	},
+}
+
+func validateWalkFunc(path string, info os.FileInfo, e error) error {
+	if !util.IsSecretFile(path) {
+		return nil
+	}
+
+	return validateFile(path)
 }
 
 func validateFile(filename string) error {

--- a/testdata/foo/bar/test_valid.yaml
+++ b/testdata/foo/bar/test_valid.yaml
@@ -1,0 +1,6 @@
+- key: FOO
+  value: bar
+- key: BAZ
+  value: 1
+- key: QUX
+  value: true

--- a/testdata/foo/test.yml
+++ b/testdata/foo/test.yml
@@ -1,0 +1,6 @@
+- key: FOO
+  value: bar
+- key: BAZ
+  value: 1
+- key: QUX
+  value: true

--- a/util/util.go
+++ b/util/util.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -12,7 +13,41 @@ import (
 
 var (
 	separatorRegExp = regexp.MustCompile(`^#+\s*[-=]{3,}`)
+	yamlExtRegexp   = regexp.MustCompile(`\.[yY][aA]?[mM][lL]$`)
 )
+
+// ListYAMLFiles parses and executes function recursively
+func ListYAMLFiles(dirname string) ([]string, error) {
+	files := []string{}
+
+	fs, err := ioutil.ReadDir(dirname)
+	if err != nil {
+		return []string{}, errors.Wrapf(err, "Failed to open directory. dirname=%s")
+	}
+
+	for _, file := range fs {
+		if file.IsDir() {
+			childDir := filepath.Join(dirname, file.Name())
+
+			childFiles, err := ListYAMLFiles(childDir)
+			if err != nil {
+				return []string{}, errors.Wrapf(err, "failed to parse directory. dirname=%s", childDir)
+			}
+
+			files = append(files, childFiles...)
+
+			continue
+		}
+
+		if strings.HasPrefix(file.Name(), ".") || !yamlExtRegexp.Match([]byte(file.Name())) {
+			continue
+		}
+
+		files = append(files, filepath.Join(dirname, file.Name()))
+	}
+
+	return files, nil
+}
 
 // WriteFile writes body to file
 func WriteFile(filename string, body []byte) error {

--- a/util/util.go
+++ b/util/util.go
@@ -16,6 +16,21 @@ var (
 	yamlExtRegexp   = regexp.MustCompile(`\.[yY][aA]?[mM][lL]$`)
 )
 
+// NamespaceFromPath returns namespace from the given path
+func NamespaceFromPath(path, basedir string) string {
+	var namespace string
+
+	namespace = strings.Replace(path, basedir, "", 1)
+	namespace = filepath.ToSlash(namespace)
+	namespace = yamlExtRegexp.ReplaceAllString(namespace, "")
+
+	if strings.HasPrefix(namespace, "/") {
+		namespace = namespace[1:len(namespace)]
+	}
+
+	return namespace
+}
+
 // ListYAMLFiles parses and executes function recursively
 func ListYAMLFiles(dirname string) ([]string, error) {
 	files := []string{}

--- a/util/util.go
+++ b/util/util.go
@@ -61,11 +61,13 @@ func ListYAMLFiles(dirname string) ([]string, error) {
 			continue
 		}
 
-		if strings.HasPrefix(file.Name(), ".") || !yamlExtRegexp.Match([]byte(file.Name())) {
+		filename := filepath.Join(dirname, file.Name())
+
+		if !IsSecretFile(filename) {
 			continue
 		}
 
-		files = append(files, filepath.Join(dirname, file.Name()))
+		files = append(files, filename)
 	}
 
 	return files, nil

--- a/util/util.go
+++ b/util/util.go
@@ -16,6 +16,13 @@ var (
 	yamlExtRegexp   = regexp.MustCompile(`\.[yY][aA]?[mM][lL]$`)
 )
 
+// IsSecretFile returns whether the given file is secret file or not
+func IsSecretFile(filename string) bool {
+	base := filepath.Base(filename)
+
+	return !strings.HasPrefix(base, ".") && yamlExtRegexp.MatchString(filepath.Ext(base))
+}
+
 // NamespaceFromPath returns namespace from the given path
 func NamespaceFromPath(path, basedir string) string {
 	var namespace string

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 )
 
@@ -34,6 +35,23 @@ func TestSeparatorRegexp(t *testing.T) {
 		if separatorRegExp.Match([]byte(s)) {
 			t.Errorf("String %q should not be matched to regexp.", s)
 		}
+	}
+}
+
+func TestListYAMLFiles(t *testing.T) {
+	dirname := filepath.Join("..", "testdata", "foo")
+	expected := []string{
+		filepath.Join("..", "testdata", "foo", "bar", "test_valid.yaml"),
+		filepath.Join("..", "testdata", "foo", "test.yml"),
+	}
+
+	actual, err := ListYAMLFiles(dirname)
+	if err != nil {
+		t.Errorf("Error should not raised. err: %s", err)
+	}
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("YAML file list is wrong. expected: %q, actual: %q", expected, actual)
 	}
 }
 

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -38,6 +38,37 @@ func TestSeparatorRegexp(t *testing.T) {
 	}
 }
 
+func TestIsSecretFile(t *testing.T) {
+	testcases := []struct {
+		filename string
+		expected bool
+	}{
+		{
+			filename: filepath.Join("secrets", "foo.yml"),
+			expected: true,
+		},
+		{
+			filename: filepath.Join("secrets", "foo", "bar.yaml"),
+			expected: true,
+		},
+		{
+			filename: filepath.Join("secrets", "foo", "bar"),
+			expected: false,
+		},
+		{
+			filename: filepath.Join("secrets", "foo", ".env"),
+			expected: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		actual := IsSecretFile(tc.filename)
+		if actual != tc.expected {
+			t.Errorf("IsSecretFile result is wrong. filename: %s, expected: %t, actual: %t", tc.filename, tc.expected, actual)
+		}
+	}
+}
+
 func TestNamespaceFromPath(t *testing.T) {
 	testcases := []struct {
 		path     string

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -38,6 +38,43 @@ func TestSeparatorRegexp(t *testing.T) {
 	}
 }
 
+func TestNamespaceFromPath(t *testing.T) {
+	testcases := []struct {
+		path     string
+		basedir  string
+		expected string
+	}{
+		{
+			path:     filepath.Join("secrets", "foo.yml"),
+			basedir:  "secrets",
+			expected: "foo",
+		},
+		{
+			path:     filepath.Join("secrets", "foo", "bar.yml"),
+			basedir:  "secrets",
+			expected: "foo/bar",
+		},
+		{
+			path:     filepath.Join("secrets", "foo", "bar.yml"),
+			basedir:  filepath.Join("secrets", "foo"),
+			expected: "bar",
+		},
+		{
+			path:     filepath.Join("secrets", "foo", "bar", "baz.yaml"),
+			basedir:  "secrets",
+			expected: "foo/bar/baz",
+		},
+	}
+
+	for _, tc := range testcases {
+		actual := NamespaceFromPath(tc.path, tc.basedir)
+
+		if actual != tc.expected {
+			t.Errorf("Namespace does not match. expected: %q, actual: %q", tc.expected, actual)
+		}
+	}
+}
+
 func TestListYAMLFiles(t *testing.T) {
 	dirname := filepath.Join("..", "testdata", "foo")
 	expected := []string{


### PR DESCRIPTION
## WHY

Current `valec validate` does NOT validates nested secret files.
e.g. `valec validate secrets` -> `secrets/foo.yml` will be validated, but `secrets/foo/production.yml` will NOT be validated.

## WHAT

Walk the given directory recursively and validate all secret files.
The algorithm walking directory is quite similar to `validate sync`, so I created common functions in `util` package and let both `validate` and `sync` use these common functions/