### PR TITLE
Encrypt multiple secrets at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,8 @@ Encrypt secret
 With `--add FILE` flag, encrypted secret will be added to the specified file.
 
 ```bash
-$ valec encrypt NAME=awesome
+$ valec encrypt NAME=awesome DATABASE_URL=postgres://example.com/dbname
+AQECAHi1osu8IsEnPMo1...
 AQECAHi1osu8IsEnPMo1...
 
 $ valec encrypt NAME=awesome --add secrets.yml


### PR DESCRIPTION
## WHY

Currently `valec encrypt` accepts only one secret at once. To encrypt multiple secrets, we have to execute `valec encrypt` as much as the number of secrets.

## WHAT

Make `valec encrypt` be able to accept multiple secrets.

```bash
$ valec encrypt FOO=bar BAR=baz
```