### PR TITLE
Add `valec dotenv` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Valec enables you to manage application secrets in your favorite VCS.
 
 ### `valec dotenv`
 
-Generate `.env` using `.env.sample` if exists. This command is equivalent to `valec dump --template .env.sample --out .env`.
+Generate `.env` using `.env.sample` if exists. This command is equivalent to `valec dump --template .env.sample --output .env`.
 
 ```bash
 $ valec dotenv

--- a/README.md
+++ b/README.md
@@ -59,6 +59,16 @@ Valec enables you to manage application secrets in your favorite VCS.
 
 ## Usage
 
+### `valec dotenv`
+
+Generate `.env` using `.env.sample` if exists. This command is equivalent to `valec dump --template .env.sample --out .env`.
+
+```bash
+$ valec dotenv
+$ cat .env
+HOGE=fuga
+```
+
 ### `valec dump`
 
 Dump secrets in dotenv format

--- a/cmd/dotenv.go
+++ b/cmd/dotenv.go
@@ -1,0 +1,69 @@
+package cmd
+
+import (
+	"os"
+	"strings"
+
+	"github.com/dtan4/valec/aws"
+	"github.com/dtan4/valec/util"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+const (
+	dotenvName       = ".env"
+	dotenvSampleName = ".env.sample"
+)
+
+// dotenvCmd represents the dotenv command
+var dotenvCmd = &cobra.Command{
+	Use:   "dotenv NAMESPACE",
+	Short: "Generate .env using .env.sample",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 1 {
+			return errors.New("Please specify namespace.")
+		}
+		namespace := args[0]
+
+		secrets, err := aws.DynamoDB.ListSecrets(tableName, namespace)
+		if err != nil {
+			return errors.Wrap(err, "Failed to retrieve secrets.")
+		}
+
+		if len(secrets) == 0 {
+			return errors.Errorf("Namespace %s does not exist.", namespace)
+		}
+
+		var (
+			dotenv []string
+			err2   error
+		)
+
+		if _, err := os.Stat(dotenvSampleName); err != nil {
+			if os.IsNotExist(err) {
+				dotenv, err2 = dumpAll(secrets, quote)
+				if err2 != nil {
+					return errors.Wrap(err, "Failed to dump all secrets.")
+				}
+			} else {
+				return errors.Wrapf(err, "Failed to get stat of dotenv template. filename=%s", dotenvSampleName)
+			}
+		} else {
+			dotenv, err2 = dumpWithTemplate(secrets, quote)
+			if err2 != nil {
+				return errors.Wrap(err, "Failed to dump secrets with dotenv template.")
+			}
+		}
+
+		body := []byte(strings.Join(dotenv, "\n") + "\n")
+		if err := util.WriteFileWithoutSection(dotenvName, body); err != nil {
+			return errors.Wrapf(err, "Failed to write dotenv file. filename=%s", dotenvName)
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(dotenvCmd)
+}

--- a/cmd/dotenv.go
+++ b/cmd/dotenv.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"strings"
 
@@ -41,6 +42,8 @@ var dotenvCmd = &cobra.Command{
 
 		if _, err := os.Stat(dotenvSampleName); err != nil {
 			if os.IsNotExist(err) {
+				fmt.Fprintf(os.Stderr, "%s does not exist. Dumping all secrets...\n", dotenvSampleName)
+
 				dotenv, err2 = dumpAll(secrets, quote)
 				if err2 != nil {
 					return errors.Wrap(err, "Failed to dump all secrets.")

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -1,13 +1,10 @@
 package cmd
 
 import (
-	"bufio"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/dtan4/valec/aws"
-	"github.com/dtan4/valec/secret"
 	"github.com/dtan4/valec/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -53,82 +50,18 @@ var dumpCmd = &cobra.Command{
 		} else {
 			body := []byte(strings.Join(dotenv, "\n") + "\n")
 			if override {
-				util.WriteFile(output, body)
+				if err := util.WriteFile(output, body); err != nil {
+					return errors.Wrapf(err, "Failed to write dotenv file. filename=%s", output)
+				}
 			} else {
-				util.WriteFileWithoutSection(output, body)
+				if err := util.WriteFileWithoutSection(output, body); err != nil {
+					return errors.Wrapf(err, "Failed to write dotenv file. filename=%s", output)
+				}
 			}
 		}
 
 		return nil
 	},
-}
-
-func dumpAll(secrets secret.Secrets, quote bool) ([]string, error) {
-	dotenv := []string{}
-
-	for _, secret := range secrets {
-		plainValue, err := aws.KMS.DecryptBase64(secret.Key, secret.Value)
-		if err != nil {
-			return []string{}, errors.Wrap(err, "Failed to decrypt value.")
-		}
-
-		if quote {
-			dotenv = append(dotenv, fmt.Sprintf("%s=%q", secret.Key, plainValue))
-		} else {
-			dotenv = append(dotenv, fmt.Sprintf("%s=%s", secret.Key, plainValue))
-		}
-	}
-
-	return dotenv, nil
-}
-
-func dumpWithTemplate(secrets secret.Secrets, quote bool) ([]string, error) {
-	fp, err := os.Open(dotenvTemplate)
-	if err != nil {
-		return []string{}, errors.Wrapf(err, "Failed to open dotenv template. filename=%s", dotenvTemplate)
-	}
-	defer fp.Close()
-
-	secretMap := secrets.ListToMap()
-	sc := bufio.NewScanner(fp)
-	dotenv := []string{}
-
-	for sc.Scan() {
-		line := sc.Text()
-
-		if strings.HasPrefix(line, "#") {
-			dotenv = append(dotenv, line)
-			continue
-		}
-
-		ss := strings.SplitN(line, "=", 2)
-		if len(ss) != 2 {
-			dotenv = append(dotenv, line)
-			continue
-		}
-
-		key, value := ss[0], ss[1]
-
-		if override || value == "" {
-			v, ok := secretMap[key]
-			if ok {
-				plainValue, err := aws.KMS.DecryptBase64(key, v)
-				if err != nil {
-					return []string{}, errors.Wrap(err, "Failed to decrypt value.")
-				}
-
-				value = plainValue
-			}
-		}
-
-		if quote {
-			dotenv = append(dotenv, fmt.Sprintf("%s=%q", key, value))
-		} else {
-			dotenv = append(dotenv, fmt.Sprintf("%s=%s", key, value))
-		}
-	}
-
-	return dotenv, nil
 }
 
 func init() {

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -1,0 +1,80 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/dtan4/valec/aws"
+	"github.com/dtan4/valec/secret"
+	"github.com/pkg/errors"
+)
+
+func dumpAll(secrets secret.Secrets, quote bool) ([]string, error) {
+	dotenv := []string{}
+
+	for _, secret := range secrets {
+		plainValue, err := aws.KMS.DecryptBase64(secret.Key, secret.Value)
+		if err != nil {
+			return []string{}, errors.Wrap(err, "Failed to decrypt value.")
+		}
+
+		if quote {
+			dotenv = append(dotenv, fmt.Sprintf("%s=%q", secret.Key, plainValue))
+		} else {
+			dotenv = append(dotenv, fmt.Sprintf("%s=%s", secret.Key, plainValue))
+		}
+	}
+
+	return dotenv, nil
+}
+
+func dumpWithTemplate(secrets secret.Secrets, quote bool) ([]string, error) {
+	fp, err := os.Open(dotenvTemplate)
+	if err != nil {
+		return []string{}, errors.Wrapf(err, "Failed to open dotenv template. filename=%s", dotenvTemplate)
+	}
+	defer fp.Close()
+
+	secretMap := secrets.ListToMap()
+	sc := bufio.NewScanner(fp)
+	dotenv := []string{}
+
+	for sc.Scan() {
+		line := sc.Text()
+
+		if strings.HasPrefix(line, "#") {
+			dotenv = append(dotenv, line)
+			continue
+		}
+
+		ss := strings.SplitN(line, "=", 2)
+		if len(ss) != 2 {
+			dotenv = append(dotenv, line)
+			continue
+		}
+
+		key, value := ss[0], ss[1]
+
+		if override || value == "" {
+			v, ok := secretMap[key]
+			if ok {
+				plainValue, err := aws.KMS.DecryptBase64(key, v)
+				if err != nil {
+					return []string{}, errors.Wrap(err, "Failed to decrypt value.")
+				}
+
+				value = plainValue
+			}
+		}
+
+		if quote {
+			dotenv = append(dotenv, fmt.Sprintf("%s=%q", key, value))
+		} else {
+			dotenv = append(dotenv, fmt.Sprintf("%s=%s", key, value))
+		}
+	}
+
+	return dotenv, nil
+}


### PR DESCRIPTION
## WHY

It's troublesome to type `valec dump --template .env.sample --output .env` every time.

## WHAT

Create `valec dotenv` command as an alias of the above command.
