### PR TITLE
Interactive encrypt mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ $ cat secrets.yml
   value: AQECAHi1osu8IsEnPMo1...
 ```
 
-Secrets can also be read from stdin using dash (`-`).
+Secrets can also be read from stdin using dash (`-`),
 
 ```bash
 $ cat .env
@@ -159,6 +159,13 @@ NAME=awesome
 DATABASE_URL=postgres://example.com/dbname
 
 $ cat .env | valec encrypt -
+```
+
+or entered interactively.
+
+```bash
+$ valec encrypt -i NAME DATABASE_URL
+NAME:
 ```
 
 ### `valec exec`

--- a/cmd/encrypt.go
+++ b/cmd/encrypt.go
@@ -149,12 +149,7 @@ func readFromArgsInteractive(args []string) (map[string]string, error) {
 
 	for _, arg := range args {
 		key := arg
-		fmt.Printf("%s: ", arg)
-
-		value, err := scanNoEcho()
-		if err != nil {
-			return map[string]string{}, errors.Wrap(err, "Failed to read secret value.")
-		}
+		value := scanNoEcho(key)
 
 		cipherText, err := aws.KMS.EncryptBase64(keyAlias, key, value)
 		if err != nil {

--- a/cmd/encrypt.go
+++ b/cmd/encrypt.go
@@ -13,7 +13,7 @@ import (
 
 // encryptCmd represents the encrypt command
 var encryptCmd = &cobra.Command{
-	Use:   "encrypt [KEY1=VALUE1 [KEY2=VALUE2 ...]] [-]",
+	Use:   "encrypt [KEY1=VALUE1 [KEY2=VALUE2 ...]] [-] [-i KEY1 [KEY2 ...]]",
 	Short: "Encrypt secret",
 	Long: `Encrypt secret
 
@@ -24,7 +24,13 @@ Read from stdin:
   $ cat .env
   KEY1=VALUE1
   KEY2=VALUE2
-  $ cat .env | valec encrypt -`,
+  $ cat .env | valec encrypt -
+
+Enter secret value interactively:
+  $ valec encrypt -i KEY1 KEY2
+  KEY1:
+  KEY2:
+`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
 			return errors.New("Please specify KEY=VALUE.")
@@ -40,6 +46,7 @@ Read from stdin:
 			}
 		} else {
 			if interactive {
+				fmt.Println("Entered secret value will be hidden.")
 				secretMap, err = readFromArgsInteractive(args)
 				if err != nil {
 					return errors.Wrap(err, "Failed to read secret from args.")

--- a/cmd/flag_vars.go
+++ b/cmd/flag_vars.go
@@ -14,6 +14,7 @@ var (
 	secretFile     string
 	dotenvTemplate string
 	dryRun         bool
+	interactive    bool
 	output         string
 	override       bool
 	quote          bool

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -7,9 +7,9 @@ import (
 	"os"
 	"strings"
 
+	"github.com/Songmu/prompter"
 	"github.com/dtan4/valec/aws"
 	"github.com/dtan4/valec/secret"
-	"github.com/howeyc/gopass"
 	"github.com/pkg/errors"
 )
 
@@ -92,11 +92,6 @@ func scanLines(r io.Reader) []string {
 	return lines
 }
 
-func scanNoEcho() (string, error) {
-	pass, err := gopass.GetPasswd()
-	if err != nil {
-		return "", errors.Wrap(err, "Failed to read secret value.")
-	}
-
-	return string(pass), nil
+func scanNoEcho(key string) string {
+	return prompter.Password(key)
 }

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/dtan4/valec/aws"
 	"github.com/dtan4/valec/secret"
+	"github.com/howeyc/gopass"
 	"github.com/pkg/errors"
 )
 
@@ -80,7 +81,7 @@ func dumpWithTemplate(secrets secret.Secrets, quote bool) ([]string, error) {
 	return dotenv, nil
 }
 
-func scanFromStdin(r io.Reader) []string {
+func scanLines(r io.Reader) []string {
 	lines := []string{}
 	sc := bufio.NewScanner(r)
 
@@ -89,4 +90,13 @@ func scanFromStdin(r io.Reader) []string {
 	}
 
 	return lines
+}
+
+func scanNoEcho() (string, error) {
+	pass, err := gopass.GetPasswd()
+	if err != nil {
+		return "", errors.Wrap(err, "Failed to read secret value.")
+	}
+
+	return string(pass), nil
 }

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 1c2dca550c8df704be8e0b82314a7ee5903c306479ca2c1fb7d4104638c197fe
-updated: 2016-12-21T15:09:49.827385065+09:00
+hash: 43e17552c53a95a4d5528c678cd3642d2eccb42d0935f9fdb508d6dfe68843d9
+updated: 2016-12-21T15:58:54.561789331+09:00
 imports:
 - name: github.com/aws/aws-sdk-go
   version: 83d2e4131e326025fac43eef89873b340f4cc8c0
@@ -49,10 +49,16 @@ imports:
   version: 30a891c33c7cde7b02a981314b4228ec99380cca
 - name: github.com/pkg/errors
   version: 645ef00459ed84a119197bfb8d8205042c6df63d
+- name: github.com/Songmu/prompter
+  version: b5721e8d556682bcef33262731d98a39dee14dc4
 - name: github.com/spf13/cobra
   version: b62566898a99f2db9c68ed0026aa0a052e59678d
 - name: github.com/spf13/pflag
   version: 25f8b5b07aece3207895bf19f7ab517eb3b22a40
+- name: golang.org/x/crypto
+  version: d8e61c69ab46ca38328da2f4995abaf93b252290
+  subpackages:
+  - ssh/terminal
 - name: golang.org/x/sys
   version: d75a52659825e75fff6158388dddc6a5b04f9ba5
   subpackages:

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: cebef35f679931043721f88264f4a686460613fc817d1c772b76ab70e4f44b4d
-updated: 2016-12-21T15:02:24.020783186+09:00
+hash: 1c2dca550c8df704be8e0b82314a7ee5903c306479ca2c1fb7d4104638c197fe
+updated: 2016-12-21T15:09:49.827385065+09:00
 imports:
 - name: github.com/aws/aws-sdk-go
   version: 83d2e4131e326025fac43eef89873b340f4cc8c0
@@ -37,6 +37,8 @@ imports:
   version: dea9d3a26a087187530244679c1cfb3a42937794
 - name: github.com/go-ini/ini
   version: 2ba15ac2dc9cdf88c110ec2dc0ced7fa45f5678c
+- name: github.com/howeyc/gopass
+  version: f5387c492211eb133053880d23dfae62aa14123d
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 - name: github.com/jmespath/go-jmespath

--- a/glide.yaml
+++ b/glide.yaml
@@ -13,4 +13,5 @@ import:
   version: ~0.8.0
 - package: github.com/fatih/color
   version: ~1.1.0
-- package: github.com/howeyc/gopass
+- package: github.com/Songmu/prompter
+  version: ~0.1.0

--- a/glide.yaml
+++ b/glide.yaml
@@ -13,3 +13,4 @@ import:
   version: ~0.8.0
 - package: github.com/fatih/color
   version: ~1.1.0
+- package: github.com/howeyc/gopass


### PR DESCRIPTION
## WHY

`$ valec encrypt KEY=value` style has an problem that secret value will remain in shell history. It's absolutely insecure.

## WHAT

Add `-i` flag to make users enable to input secret value interactively. Entered value will be hidden.