### PR TITLE
Calculate namespace from full path

### DIFF
--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -43,7 +43,10 @@ func doSync(cmd *cobra.Command, args []string) error {
 }
 
 func syncFile(filename, dirname string) error {
-	namespace := util.NamespaceFromPath(filename, dirname)
+	namespace, err := util.NamespaceFromPath(filename, dirname)
+	if err != nil {
+		return errors.Wrap(err, "Failed to get full path")
+	}
 
 	if rootOpts.noColor {
 		fmt.Println(namespace)

--- a/util/util.go
+++ b/util/util.go
@@ -26,10 +26,20 @@ func IsSecretFile(filename string) bool {
 }
 
 // NamespaceFromPath returns namespace from the given path
-func NamespaceFromPath(path, basedir string) string {
+func NamespaceFromPath(path, basedir string) (string, error) {
 	var namespace string
 
-	namespace = strings.Replace(path, basedir, "", 1)
+	fullpath, err := filepath.Abs(path)
+	if err != nil {
+		return "", errors.Wrapf(err, "Failed to get full path of file. filename=%s", path)
+	}
+
+	fulldir, err := filepath.Abs(basedir)
+	if err != nil {
+		return "", errors.Wrapf(err, "Failed to get full path of directory. dirname=%s", basedir)
+	}
+
+	namespace = strings.Replace(fullpath, fulldir, "", 1)
 	namespace = filepath.ToSlash(namespace)
 	namespace = yamlExtRegexp.ReplaceAllString(namespace, "")
 
@@ -37,7 +47,7 @@ func NamespaceFromPath(path, basedir string) string {
 		namespace = namespace[1:len(namespace)]
 	}
 
-	return namespace
+	return namespace, nil
 }
 
 // ListYAMLFiles parses and executes function recursively

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -82,6 +82,11 @@ func TestNamespaceFromPath(t *testing.T) {
 			expected: "foo",
 		},
 		{
+			path:     filepath.Join("secrets", "foo.yml"),
+			basedir:  ".",
+			expected: "secrets/foo",
+		},
+		{
 			path:     filepath.Join("secrets", "foo", "bar.yml"),
 			basedir:  "secrets",
 			expected: "foo/bar",
@@ -99,7 +104,10 @@ func TestNamespaceFromPath(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		actual := NamespaceFromPath(tc.path, tc.basedir)
+		actual, err := NamespaceFromPath(tc.path, tc.basedir)
+		if err != nil {
+			t.Errorf("Error should not be raised. error: %s", err)
+		}
 
 		if actual != tc.expected {
 			t.Errorf("Namespace does not match. expected: %q, actual: %q", tc.expected, actual)


### PR DESCRIPTION
## WHY

If users specify directory to sync as `.` or `..`, incorrect namespace will be synchronized.

For example, to synchronize `foobar.yml` in current directory:

```bash
$ valec sync --dry-run .
foobaryml
...
```

## WHAT

Calculate namespace from full path both filename and base directory.

```
$ valec sync --dry-run .
foobar
```