### PR TITLE
Delete namespace correctly

### DIFF
--- a/aws/dynamodb/dynamodb_test.go
+++ b/aws/dynamodb/dynamodb_test.go
@@ -118,6 +118,55 @@ func TestDeleteNamespace(t *testing.T) {
 
 	api := mock.NewMockDynamoDBAPI(ctrl)
 
+	api.EXPECT().Query(&dynamodb.QueryInput{
+		TableName: aws.String("valec"),
+		KeyConditions: map[string]*dynamodb.Condition{
+			"namespace": &dynamodb.Condition{
+				ComparisonOperator: aws.String(dynamodb.ComparisonOperatorEq),
+				AttributeValueList: []*dynamodb.AttributeValue{
+					&dynamodb.AttributeValue{
+						S: aws.String("test"),
+					},
+				},
+			},
+		},
+	}).Return(&dynamodb.QueryOutput{
+		Items: []map[string]*dynamodb.AttributeValue{
+			map[string]*dynamodb.AttributeValue{
+				"namespace": &dynamodb.AttributeValue{
+					S: aws.String("test"),
+				},
+				"key": &dynamodb.AttributeValue{
+					S: aws.String("BAZ"),
+				},
+				"value": &dynamodb.AttributeValue{
+					S: aws.String("1"),
+				},
+			},
+			map[string]*dynamodb.AttributeValue{
+				"namespace": &dynamodb.AttributeValue{
+					S: aws.String("test"),
+				},
+				"key": &dynamodb.AttributeValue{
+					S: aws.String("FOO"),
+				},
+				"value": &dynamodb.AttributeValue{
+					S: aws.String("bar"),
+				},
+			},
+			map[string]*dynamodb.AttributeValue{
+				"namespace": &dynamodb.AttributeValue{
+					S: aws.String("test"),
+				},
+				"key": &dynamodb.AttributeValue{
+					S: aws.String("BAR"),
+				},
+				"value": &dynamodb.AttributeValue{
+					S: aws.String("fuga"),
+				},
+			},
+		},
+	}, nil)
 	api.EXPECT().BatchWriteItem(&dynamodb.BatchWriteItemInput{
 		RequestItems: map[string][]*dynamodb.WriteRequest{
 			"valec": []*dynamodb.WriteRequest{
@@ -126,6 +175,33 @@ func TestDeleteNamespace(t *testing.T) {
 						Key: map[string]*dynamodb.AttributeValue{
 							"namespace": &dynamodb.AttributeValue{
 								S: aws.String("test"),
+							},
+							"key": &dynamodb.AttributeValue{
+								S: aws.String("BAZ"),
+							},
+						},
+					},
+				},
+				&dynamodb.WriteRequest{
+					DeleteRequest: &dynamodb.DeleteRequest{
+						Key: map[string]*dynamodb.AttributeValue{
+							"namespace": &dynamodb.AttributeValue{
+								S: aws.String("test"),
+							},
+							"key": &dynamodb.AttributeValue{
+								S: aws.String("FOO"),
+							},
+						},
+					},
+				},
+				&dynamodb.WriteRequest{
+					DeleteRequest: &dynamodb.DeleteRequest{
+						Key: map[string]*dynamodb.AttributeValue{
+							"namespace": &dynamodb.AttributeValue{
+								S: aws.String("test"),
+							},
+							"key": &dynamodb.AttributeValue{
+								S: aws.String("BAR"),
 							},
 						},
 					},

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -72,7 +72,7 @@ func doSync(cmd *cobra.Command, args []string) error {
 				}
 			}
 
-			fmt.Printf("  %d namespaces were successfully deleted.\n", len(deleted))
+			fmt.Printf("%d namespaces were successfully deleted.\n", len(deleted))
 		}
 	}
 


### PR DESCRIPTION
## WHY

Valec creates DynamoDB table which has two keys: `namespace` as hash key and `key` as range key. When we try to delete a certain namespace, we have to pass _both_ `namespace` and `key` to `BatchWriteItem` API call.

## WHAT

Retrieve all items in the given namespace at first, then try to delete namespace.