### PR TITLE
Stop parsing flags which locates after subcommand

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -61,4 +61,6 @@ func doExec(cmd *cobra.Command, args []string) error {
 
 func init() {
 	RootCmd.AddCommand(execCmd)
+
+	execCmd.Flags().SetInterspersed(false)
 }


### PR DESCRIPTION
Close #49 

## WHY

`valec exec` cannot execute command with flags, e.g. `valec exec sample ls -l`, because these options are captured by spf13/cobra framework.

## WHAT

Stop parsing flags after subcommand.

```bash
$ valec exec sample ls -l
total 88
-rw-r--r--   1 dtan4  staff  3707  1 17 11:36 CHANGELOG.md
-rw-r--r--   1 dtan4  staff  1081 11 24 12:03 LICENSE
-rw-r--r--   1 dtan4  staff  1613  1 17 11:36 Makefile
-rw-r--r--   1 dtan4  staff  6110 12 22 20:44 README.md
-rw-r--r--   1 dtan4  staff   417 12  9 15:09 appveyor.yml
drwxr-xr-x   6 dtan4  staff   204 12 26 16:56 aws
drwxr-xr-x   3 dtan4  staff   102  1 18 18:23 bin
drwxr-xr-x  14 dtan4  staff   476  1 18 18:23 cmd
-rw-r--r--   1 dtan4  staff  7511 12 26 16:51 coverage.txt
drwxr-xr-x   9 dtan4  staff   306  1 17 15:19 dist
-rw-r--r--   1 dtan4  staff  2167 12 26 16:56 glide.lock
-rw-r--r--   1 dtan4  staff   452 12 26 16:56 glide.yaml
-rw-r--r--   1 dtan4  staff    82 11 24 14:18 main.go
drwxr-xr-x   4 dtan4  staff   136 12 26 19:21 msg
drwxr-xr-x   4 dtan4  staff   136 12 22 20:41 secret
drwxr-xr-x   7 dtan4  staff   238 12 22 20:41 testdata
drwxr-xr-x   5 dtan4  staff   170 12  2 15:46 tmp
drwxr-xr-x   4 dtan4  staff   136 12 26 19:21 util
drwxr-xr-x   5 dtan4  staff   170 12 26 14:42 vendor
```

## REF

- [Question about arbitrary flags · Issue #352 · spf13/cobra](https://github.com/spf13/cobra/issues/352)