### PR TITLE
Add Stdin to execCommand

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -48,6 +48,7 @@ func doExec(cmd *cobra.Command, args []string) error {
 	execCmd.Env = envs
 	execCmd.Stderr = os.Stderr
 	execCmd.Stdout = os.Stdout
+	execCmd.Stdin = os.Stdin
 	err = execCmd.Run()
 
 	if execCmd.Process == nil {


### PR DESCRIPTION
## WHY

Same issue as https://github.com/wantedly/developers-account-mapper/pull/29
exec command can not be used with subcommand which requires stdin.

## WHAT

Add stdin in exec command
Since, this is a fork, I could not test it.
If you want me to do some test, give me some time.