### PR TITLE
Implement `valec get` command

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/dtan4/valec/aws"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+// getCmd represents the get command
+var getCmd = &cobra.Command{
+	Use:   "get NAMESPACE KEY",
+	Short: "Get secret",
+	RunE:  doGet,
+}
+
+func doGet(cmd *cobra.Command, args []string) error {
+	if len(args) != 2 {
+		return errors.New("Please specify both namespace and key.")
+	}
+	namespace, key := args[0], args[1]
+
+	secret, err := aws.DynamoDB.Get(rootOpts.tableName, namespace, key)
+	if err != nil {
+		return errors.Wrap(err, "Failed to retrieve secret.")
+	}
+
+	plainValue, err := aws.KMS.DecryptBase64(secret.Key, secret.Value)
+	if err != nil {
+		return errors.Wrap(err, "Failed to decrypt secret.")
+	}
+
+	fmt.Printf(plainValue)
+
+	return nil
+}
+
+func init() {
+	RootCmd.AddCommand(getCmd)
+}


### PR DESCRIPTION
## WHY

We sometimes want to get a certain secret by Valec. Now we use ERB template to embed secret to file or command arguments, but it requires Ruby to generate it.

The below style is preferred.

```bash
$ docker run -e API_KEY=`valec get awesomeapp API_KEY` dtan4/awesome:v1.2.0 bin/server
```

## WHAT

Implement `valec get` command to retrieve a secret. It prints the decrypted value of the given secret, without breakline `\n`.

```bash
$ valec get sample PPAP
pen-pinapple-apple-pen
```
