### PR TITLE
Create directory by `valec encrypt`

### DIFF
--- a/secret/secret.go
+++ b/secret/secret.go
@@ -2,8 +2,11 @@ package secret
 
 import (
 	"io/ioutil"
+	"os"
+	"path/filepath"
 	"sort"
 
+	"github.com/dtan4/valec/util"
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 )
@@ -105,6 +108,13 @@ func (ss Secrets) SaveAsYAML(filename, kmsKey string) error {
 	body, err := yaml.Marshal(y)
 	if err != nil {
 		return errors.Wrap(err, "Failed to convert secrets as YAML.")
+	}
+
+	dir := filepath.Dir(filename)
+	if !util.IsExist(dir) {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return errors.Wrapf(err, "failed to create directory %q", dir)
+		}
 	}
 
 	if err := ioutil.WriteFile(filename, body, 0644); err != nil {

--- a/util/util.go
+++ b/util/util.go
@@ -48,6 +48,12 @@ func CompareStrings(src, dst []string) ([]string, []string) {
 	return added, deleted
 }
 
+// IsExist returns whether the given file / directory exists or not
+func IsExist(name string) bool {
+	_, err := os.Stat(name)
+	return err == nil || os.IsExist(err)
+}
+
 // IsSecretFile returns whether the given file is secret file or not
 func IsSecretFile(filename string) bool {
 	base := filepath.Base(filename)

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -68,6 +68,43 @@ func TestCompareStrings(t *testing.T) {
 	}
 }
 
+func TestIsExist(t *testing.T) {
+	dir, err := ioutil.TempDir("", "test-save-as-dotenv")
+	if err != nil {
+		t.Fatalf("Failed to create tempdir. dir: %s", dir)
+	}
+	defer os.RemoveAll(dir)
+
+	name := filepath.Join(dir, "sample")
+	if err := ioutil.WriteFile(name, []byte("test"), 0644); err != nil {
+		t.Fatalf("Failed to create tempfile. name: %s", name)
+	}
+
+	testcases := []struct {
+		name     string
+		expected bool
+	}{
+		{
+			name:     "",
+			expected: true,
+		},
+		{
+			name:     "sample",
+			expected: true,
+		},
+		{
+			name:     "nonexist",
+			expected: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		if IsExist(filepath.Join(dir, tc.name)) != tc.expected {
+			t.Errorf("IsExist result is wrong. filename: %s, expected: %t", tc.name, tc.expected)
+		}
+	}
+}
+
 func TestIsSecretFile(t *testing.T) {
 	testcases := []struct {
 		filename string


### PR DESCRIPTION
## WHY

If secret directory does not exist, `valec encrypt` show error and does not create any file.

```bash
$ valec encrypt --add hoge/fuga.yml -i KEY
Entered secret value will be hidden.
KEY:
Failed to flush secrets to file. filename=hoge/fuga.yml: Failed to update local secret file. filename=hoge/fuga.yml: Failed to save file. filename=hoge/fuga.yml: open hoge/fuga.yml: no such file or directory
```

## WHAT

Create secret directory if it does not exist.