### PR TITLE
Bump the version to v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# [v0.6.2](https://github.com/dtan4/valec/releases/tag/v0.6.2) (2017-02-02)
+
+Features and behaviors are the same as v0.6.1.
+This release is made to release archives with new naming rule.
+
 # [v0.6.1](https://github.com/dtan4/valec/releases/tag/v0.6.1) (2017-02-01)
 
 ## Fixed

--- a/Makefile
+++ b/Makefile
@@ -45,8 +45,8 @@ dist:
 	cd dist && \
 	$(DIST_DIRS) cp ../LICENSE {} \; && \
 	$(DIST_DIRS) cp ../README.md {} \; && \
-	$(DIST_DIRS) tar -zcf $(NAME)-$(VERSION)-{}.tar.gz {} \; && \
-	$(DIST_DIRS) zip -r $(NAME)-$(VERSION)-{}.zip {} \; && \
+	$(DIST_DIRS) tar -zcf $(NAME)-{}-$(VERSION).tar.gz {} \; && \
+	$(DIST_DIRS) zip -r $(NAME)-{}-$(VERSION).zip {} \; && \
 	cd ..
 
 .PHONY: glide

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME      := valec
-VERSION   := v0.6.1
+VERSION   := v0.6.2
 REVISION  := $(shell git rev-parse --short HEAD)
 
 SRCS      := $(shell find . -name '*.go' -type f)


### PR DESCRIPTION
## WHY

Current naming rule of releases are not compatible with Homebrew.

```
https://github.com/dtan4/valec/releases/download/v0.6.1/valec-v0.6.1-darwin-amd64.tar.gz
```

## WHAT

Make it compatible with Homebrew and release new version

```
https://github.com/dtan4/valec/releases/download/v0.6.1/valec-v0.6.1-darwin-amd64.tar.gz
```