### PR TITLE
Hide values in list command by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,9 +199,16 @@ $ valec init
 
 List stored secrets
 
+Only secret keys are shown by default.
+To show values together, use `--show-values` flag.
+
 ```bash
-# List secrets stored in DynamoDB
+# List secret keys stored in DynamoDB
 $ valec list hoge
+HOGE
+
+# List secret keys and values together
+$ valec list hoge --show-values
 HOGE: fuga
 
 # List secrets stored in local file

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -28,6 +28,7 @@ Encrypted values are decrypted and printed as plain text.`,
 
 var listOpts = struct {
 	secretFile string
+	showValues bool
 }{}
 
 func doList(cmd *cobra.Command, args []string) error {
@@ -65,7 +66,11 @@ func doList(cmd *cobra.Command, args []string) error {
 			return errors.Wrapf(err, "Failed to decrypt value. key=%q, value=%q", secret.Key, secret.Value)
 		}
 
-		fmt.Fprintf(w, "%s\t%s\n", secret.Key+":", plainValue)
+		if listOpts.showValues {
+			fmt.Fprintf(w, "%s\t%s\n", secret.Key+":", plainValue)
+		} else {
+			fmt.Fprintln(w, secret.Key)
+		}
 	}
 
 	w.Flush()
@@ -77,4 +82,5 @@ func init() {
 	RootCmd.AddCommand(listCmd)
 
 	listCmd.Flags().StringVarP(&listOpts.secretFile, "file", "f", "", "Secret file")
+	listCmd.Flags().BoolVar(&listOpts.showValues, "show-values", false, "Show values")
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -17,9 +17,11 @@ var listCmd = &cobra.Command{
 	Short: "List stored secrets",
 	Long: `List stored secrets
 
-To list secrets stored in DynamoDB, specify namespace:
+To list secret keys stored in DynamoDB, specify namespace:
   $ valec list NAMESPACE
-to list secrets stored in local file, specify file:
+To list secret values together:
+  $ valec list NAMESPACE --show-values
+To list secret keys stored in local file, specify file:
   $ valec list -f qa.yaml
 
 Encrypted values are decrypted and printed as plain text.`,


### PR DESCRIPTION
## WHY

We sometimes want to check only what keys are stored. It's not preferable to unvail secret values easily. Valec also has `dump` command.

## WHAT

Hide secrets values from `valec list` output by default. To show values together, we have to specify `--show-values` option.